### PR TITLE
feat: 게시글 목록 조회 구현

### DIFF
--- a/src/__mock__/post.mock.ts
+++ b/src/__mock__/post.mock.ts
@@ -1,0 +1,8 @@
+import { PostListItem } from '../domain/post';
+
+export const postListItemMockData: Readonly<PostListItem> = {
+  id: 1,
+  title: '게시글 제목',
+  content: '게시글 내용',
+  postedAt: new Date('2024-01-01'),
+};

--- a/src/adapter/db/post.entity.ts
+++ b/src/adapter/db/post.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'post' })
+export class PostDbEntity {
+  @PrimaryKey()
+  id: number;
+
+  @Property()
+  title: string;
+
+  @Property()
+  content: string;
+
+  @Property({ onCreate: () => new Date() })
+  createdAt: Date;
+}

--- a/src/adapter/db/post.gateway.ts
+++ b/src/adapter/db/post.gateway.ts
@@ -1,0 +1,48 @@
+import { EntityRepository } from '@mikro-orm/mysql';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { Injectable } from '@nestjs/common';
+
+import { PostDbEntity } from './post.entity';
+import { mapToPostListItem } from './post.mapper';
+import { Order } from '../../application/common/enum/Order';
+import { CursorResult } from '../../application/common/types/CursorResult';
+import { GetPostsQuery } from '../../application/port/in/post/PostUseCase';
+import { PostDbQueryPort } from '../../application/port/out/PostDbQueryPort';
+import { PostListItem } from '../../domain/post';
+
+@Injectable()
+export class PostGateway implements PostDbQueryPort {
+  constructor(
+    @InjectRepository(PostDbEntity)
+    private readonly postRepository: EntityRepository<PostDbEntity>,
+  ) {}
+
+  async getPosts(query: GetPostsQuery): Promise<CursorResult<PostListItem>> {
+    const { cursor, limit } = query;
+
+    const qb = this.postRepository.createQueryBuilder('post');
+
+    if (cursor) {
+      qb.andWhere({ id: { $lt: cursor } });
+    }
+
+    qb.orderBy({ id: Order.DESC }).limit(limit + 1);
+
+    const items = await qb.getResult();
+    return this.processCursorPagination<PostListItem>(items.map(mapToPostListItem), limit, 'id');
+  }
+
+  private processCursorPagination<T extends PostListItem>(
+    items: T[],
+    limit: number,
+    orderByField: keyof PostListItem,
+  ): CursorResult<T> {
+    const hasMore = items.length > limit;
+    if (hasMore) {
+      items.pop();
+    }
+
+    const nextCursor = hasMore ? String(items[items.length - 1][orderByField]) : undefined;
+    return { items, nextCursor, hasMore };
+  }
+}

--- a/src/adapter/db/post.mapper.ts
+++ b/src/adapter/db/post.mapper.ts
@@ -1,0 +1,11 @@
+import { PostDbEntity } from './post.entity';
+import { PostListItem } from '../../domain/post';
+
+export const mapToPostListItem = (dbEntity: PostDbEntity): PostListItem => {
+  return {
+    id: dbEntity.id,
+    title: dbEntity.title,
+    content: dbEntity.content,
+    postedAt: dbEntity.createdAt,
+  };
+};

--- a/src/adapter/web/post.controller.ts
+++ b/src/adapter/web/post.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Inject, Query } from '@nestjs/common';
+
+import { CursorResult } from '../../application/common/types/CursorResult';
+import { GetPostsQuery, PostUseCase } from '../../application/port/in/post/PostUseCase';
+import { PostListItem } from '../../domain/post';
+
+@Controller()
+export class PostController {
+  constructor(
+    @Inject('PostUseCase')
+    private readonly postUseCase: PostUseCase,
+  ) {}
+
+  @Get()
+  async getPosts(@Query() query: GetPostsQuery): Promise<CursorResult<PostListItem>> {
+    return this.postUseCase.getPosts(query);
+  }
+}

--- a/src/application/port/in/post/PostUseCase.ts
+++ b/src/application/port/in/post/PostUseCase.ts
@@ -1,0 +1,12 @@
+import { PostListItem } from 'src/domain/post';
+
+import { SwaggerDto } from '../../../../common/decorators/swagger-dto.decorator';
+import { CursorPaginationQuery } from '../../../common/query/CursorPaginationQuery';
+import { CursorResult } from '../../../common/types/CursorResult';
+
+@SwaggerDto()
+export class GetPostsQuery extends CursorPaginationQuery {}
+
+export interface PostUseCase {
+  getPosts(query: GetPostsQuery): Promise<CursorResult<PostListItem>>;
+}

--- a/src/application/port/out/PostDbQueryPort.ts
+++ b/src/application/port/out/PostDbQueryPort.ts
@@ -1,0 +1,7 @@
+import { PostListItem } from '../../../domain/post';
+import { CursorResult } from '../../common/types/CursorResult';
+import { GetPostsQuery } from '../in/post/PostUseCase';
+
+export interface PostDbQueryPort {
+  getPosts(query: GetPostsQuery): Promise<CursorResult<PostListItem>>;
+}

--- a/src/application/service/post.service.spec.ts
+++ b/src/application/service/post.service.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PostService } from './post.service';
+import { postListItemMockData } from '../../__mock__/post.mock';
+import { GetPostsQuery } from '../port/in/post/PostUseCase';
+import { PostDbQueryPort } from '../port/out/PostDbQueryPort';
+
+describe('PostService', () => {
+  let service: PostService;
+  let queryPortMock: jest.Mocked<PostDbQueryPort>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PostService,
+        {
+          provide: 'PostGateway',
+          useValue: {
+            getPosts: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<PostService>(PostService);
+    queryPortMock = module.get<jest.Mocked<PostDbQueryPort>>('PostGateway');
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getPosts', () => {
+    it('게시글 목록을 조회할 수 있다', async () => {
+      // given
+      const post = postListItemMockData;
+      queryPortMock.getPosts.mockResolvedValue({
+        items: [post],
+        nextCursor: undefined,
+        hasMore: false,
+      });
+
+      const query: GetPostsQuery = {
+        limit: 10,
+      };
+
+      // when
+      const result = await service.getPosts(query);
+
+      // then
+      expect(result).toEqual({ items: [post], nextCursor: undefined, hasMore: false });
+      expect(queryPortMock.getPosts).toHaveBeenCalledTimes(1);
+      expect(queryPortMock.getPosts).toHaveBeenCalledWith(query);
+    });
+  });
+});

--- a/src/application/service/post.service.ts
+++ b/src/application/service/post.service.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { PostListItem } from '../../domain/post';
+import { CursorResult } from '../common/types/CursorResult';
+import { GetPostsQuery, PostUseCase } from '../port/in/post/PostUseCase';
+import { PostDbQueryPort } from '../port/out/PostDbQueryPort';
+
+@Injectable()
+export class PostService implements PostUseCase {
+  constructor(
+    @Inject('PostGateway')
+    private readonly postDbQueryPort: PostDbQueryPort,
+  ) {}
+
+  async getPosts(query: GetPostsQuery): Promise<CursorResult<PostListItem>> {
+    return this.postDbQueryPort.getPosts(query);
+  }
+}

--- a/src/domain/post.ts
+++ b/src/domain/post.ts
@@ -1,0 +1,6 @@
+export class PostListItem {
+  id: number;
+  title: string;
+  content: string;
+  postedAt: Date;
+}

--- a/src/framework/module/app.module.ts
+++ b/src/framework/module/app.module.ts
@@ -1,15 +1,14 @@
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { APP_GUARD, RouterModule } from '@nestjs/core';
+import { RouterModule } from '@nestjs/core';
 
 import { AuthModule } from './auth.module';
-
-import { UserModule } from './user.module';
-import { JwtAuthGuard } from '../auth/guard';
-import createMikroOrmConfig from '../config/mikro-orm.config';
 import { CacheModule } from './cache.module';
 import { HealthModule } from './health.module';
+import { PostModule } from './post.module';
+import { UserModule } from './user.module';
+import createMikroOrmConfig from '../config/mikro-orm.config';
 
 @Module({
   imports: [
@@ -17,6 +16,7 @@ import { HealthModule } from './health.module';
     CacheModule,
     ConfigModule.forRoot({ isGlobal: true }),
     HealthModule,
+    PostModule,
     UserModule,
     MikroOrmModule.forRootAsync({
       useFactory: async () => await createMikroOrmConfig(),
@@ -30,18 +30,13 @@ import { HealthModule } from './health.module';
             path: 'v1',
             children: [
               { path: 'auth', module: AuthModule },
+              { path: 'post', module: PostModule },
               { path: 'user', module: UserModule },
             ],
           },
         ],
       },
     ]),
-  ],
-  providers: [
-    {
-      provide: APP_GUARD,
-      useClass: JwtAuthGuard,
-    },
   ],
 })
 export class AppModule {}

--- a/src/framework/module/post.module.ts
+++ b/src/framework/module/post.module.ts
@@ -1,0 +1,23 @@
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { Module } from '@nestjs/common';
+
+import { PostDbEntity } from '../../adapter/db/post.entity';
+import { PostGateway } from '../../adapter/db/post.gateway';
+import { PostController } from '../../adapter/web/post.controller';
+import { PostService } from '../../application/service/post.service';
+
+@Module({
+  imports: [MikroOrmModule.forFeature([PostDbEntity])],
+  controllers: [PostController],
+  providers: [
+    {
+      provide: 'PostUseCase',
+      useClass: PostService,
+    },
+    {
+      provide: 'PostGateway',
+      useClass: PostGateway,
+    },
+  ],
+})
+export class PostModule {}


### PR DESCRIPTION
# 개요
- 게시글 목록 조회를 구현합니다.

# 상세
- 따로 정렬 옵션 없이 descending으로 정렬되도록 했습니다.
- cursor pagination 방식으로 구현했습니다.