### PR TITLE
feat: 공통 질문 및 답변 검증 추가

### DIFF
--- a/src/__mock__/common-question.mock.ts
+++ b/src/__mock__/common-question.mock.ts
@@ -1,0 +1,7 @@
+import { CommonQuestion } from '../domain/common-question';
+
+export const commonQuestionMockData: Readonly<CommonQuestion> = {
+  step: 1,
+  question: '질문',
+  options: ['옵션1', '옵션2', '옵션3', '옵션4'],
+};

--- a/src/__mock__/index.ts
+++ b/src/__mock__/index.ts
@@ -1,3 +1,4 @@
+export * from './common-question.mock';
 export * from './post.mock';
 export * from './recommend-session.mock';
 export * from './user.mock';

--- a/src/__mock__/recommend-session.mock.ts
+++ b/src/__mock__/recommend-session.mock.ts
@@ -6,6 +6,7 @@ import {
 
 export const recommendSessionMockData: Readonly<RecommendSession> = {
   id: 'recommend-session-uuid-v7',
+  receiverName: '홍길동',
   steps: [],
   result: undefined,
   endedAt: undefined,

--- a/src/adapter/db/common-question.entity.ts
+++ b/src/adapter/db/common-question.entity.ts
@@ -14,6 +14,9 @@ export class CommonQuestionDbEntity {
   @Property({ type: 'json' })
   options: string[];
 
+  @Property({ type: 'json', nullable: true })
+  optionImages?: string[];
+
   @Property({ onCreate: () => new Date() })
   createdAt: Date;
 }

--- a/src/adapter/db/common-question.mapper.ts
+++ b/src/adapter/db/common-question.mapper.ts
@@ -6,5 +6,6 @@ export const mapToCommonQuestion = (dbEntity: CommonQuestionDbEntity): CommonQue
     step: dbEntity.step,
     question: dbEntity.question,
     options: dbEntity.options,
+    optionImages: dbEntity.optionImages,
   };
 };

--- a/src/adapter/db/recommend-session-step.entity.ts
+++ b/src/adapter/db/recommend-session-step.entity.ts
@@ -16,6 +16,9 @@ export class RecommendSessionStepDbEntity {
   @Property({ type: 'json' })
   options: string[];
 
+  @Property({ type: 'json', nullable: true })
+  optionImages?: string[];
+
   @Property({ nullable: true })
   answer?: string;
 

--- a/src/adapter/db/recommend-session.entity.ts
+++ b/src/adapter/db/recommend-session.entity.ts
@@ -19,6 +19,12 @@ export class RecommendSessionDbEntity {
   @Property({ nullable: true })
   userId?: number;
 
+  @Property()
+  deviceId: string;
+
+  @Property()
+  receiverName: string;
+
   @Property({ nullable: true })
   endedAt?: Date;
 

--- a/src/adapter/db/recommend-session.gateway.ts
+++ b/src/adapter/db/recommend-session.gateway.ts
@@ -83,6 +83,7 @@ export class RecommendSessionGateway
     stepEntity.step = lastStep ? lastStep.step + 1 : 1;
     stepEntity.question = command.question;
     stepEntity.options = command.options;
+    stepEntity.optionImages = command.optionImages;
 
     session.steps?.add(stepEntity);
     await this.em.persistAndFlush(session);

--- a/src/adapter/db/recommend-session.gateway.ts
+++ b/src/adapter/db/recommend-session.gateway.ts
@@ -10,6 +10,7 @@ import {
   mapToRecommendSessionResult,
   mapToRecommendSessionStep,
 } from './recommend-session.mapper';
+import { StartSessionCommand } from '../../application/port/in/recommend-session/RecommendSessionUseCase';
 import {
   AddStepCommand,
   CreateResultCommand,
@@ -54,9 +55,11 @@ export class RecommendSessionGateway
     return mapToRecommendSessionStep(stepEntity);
   }
 
-  async createSession(userId?: number): Promise<RecommendSession> {
+  async startSession(command: StartSessionCommand): Promise<RecommendSession> {
     const sessionEntity = new RecommendSessionDbEntity();
-    sessionEntity.userId = userId;
+    sessionEntity.deviceId = command.deviceId;
+    sessionEntity.userId = command.userId;
+    sessionEntity.receiverName = command.receiverName;
     await this.em.persistAndFlush(sessionEntity);
 
     return mapToRecommendSession(sessionEntity);

--- a/src/adapter/db/recommend-session.mapper.ts
+++ b/src/adapter/db/recommend-session.mapper.ts
@@ -29,6 +29,7 @@ export const mapToRecommendSessionStep = (
     step: dbEntity.step,
     question: dbEntity.question,
     options: dbEntity.options,
+    optionImages: dbEntity.optionImages,
     answer: dbEntity.answer,
   };
 };

--- a/src/adapter/db/recommend-session.mapper.ts
+++ b/src/adapter/db/recommend-session.mapper.ts
@@ -10,6 +10,7 @@ import {
 export const mapToRecommendSession = (dbEntity: RecommendSessionDbEntity): RecommendSession => {
   return {
     id: dbEntity.id,
+    receiverName: dbEntity.receiverName,
     steps:
       dbEntity.steps && dbEntity.steps.length > 0
         ? dbEntity.steps.map(step => mapToRecommendSessionStep(step))

--- a/src/adapter/web/recommend-session.controller.ts
+++ b/src/adapter/web/recommend-session.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Inject, Post, Delete, Param, Body } from '@nestjs/common';
 
 import {
   RecommendSessionUseCase,
+  StartSessionRequest,
   SubmitAnswerRequest,
 } from '../../application/port/in/recommend-session/RecommendSessionUseCase';
 
@@ -13,8 +14,8 @@ export class RecommendSessionController {
   ) {}
 
   @Post()
-  async startSession() {
-    return this.recommendSessionUseCase.startSession();
+  async startSession(@Body() command: StartSessionRequest) {
+    return this.recommendSessionUseCase.startSession(command);
   }
 
   @Post(':sessionId/answer')

--- a/src/application/common/error/error-messages.ts
+++ b/src/application/common/error/error-messages.ts
@@ -15,5 +15,6 @@ export const ERROR_MESSAGES = {
   RECOMMEND_SESSION: {
     ALREADY_ENDED: '이미 종료된 세션입니다.',
     NOT_FOUND: '세션을 찾을 수 없습니다.',
+    INVALID_ANSWER: '유효하지 않은 답변입니다.',
   },
 } as const;

--- a/src/application/common/error/exception/recommend-session.exception.ts
+++ b/src/application/common/error/exception/recommend-session.exception.ts
@@ -13,3 +13,9 @@ export class RecommendSessionAlreadyEndedException extends BadRequestException {
     super(ERROR_MESSAGES.RECOMMEND_SESSION.ALREADY_ENDED);
   }
 }
+
+export class RecommendSessionInvalidAnswerException extends BadRequestException {
+  constructor() {
+    super(ERROR_MESSAGES.RECOMMEND_SESSION.INVALID_ANSWER);
+  }
+}

--- a/src/application/port/in/recommend-session/RecommendSessionUseCase.ts
+++ b/src/application/port/in/recommend-session/RecommendSessionUseCase.ts
@@ -4,6 +4,19 @@ import { SwaggerDto } from '../../../../common/decorators/swagger-dto.decorator'
 import { RecommendSessionResult, RecommendSessionStep } from '../../../../domain/recommend-session';
 
 @SwaggerDto()
+export class StartSessionRequest {
+  @IsString()
+  deviceId: string;
+
+  @IsString()
+  receiverName: string;
+}
+
+export class StartSessionCommand extends StartSessionRequest {
+  userId?: number;
+}
+
+@SwaggerDto()
 export class SubmitAnswerRequest {
   @IsString()
   answer: string;
@@ -14,7 +27,7 @@ export class SubmitAnswerCommand extends SubmitAnswerRequest {
 }
 
 export interface RecommendSessionUseCase {
-  startSession(): Promise<RecommendSessionStep>;
+  startSession(command: StartSessionCommand): Promise<RecommendSessionStep>;
   submitAnswer(
     command: SubmitAnswerCommand,
   ): Promise<RecommendSessionStep | RecommendSessionResult>;

--- a/src/application/port/out/RecommendSessionDbCommandPort.ts
+++ b/src/application/port/out/RecommendSessionDbCommandPort.ts
@@ -3,6 +3,7 @@ import {
   RecommendSessionResult,
   RecommendSessionStep,
 } from '../../../domain/recommend-session';
+import { StartSessionCommand } from '../in/recommend-session/RecommendSessionUseCase';
 
 export class AddStepCommand {
   sessionId: string;
@@ -18,7 +19,7 @@ export class CreateResultCommand {
 }
 
 export interface RecommendSessionDbCommandPort {
-  createSession(userId?: number): Promise<RecommendSession>;
+  startSession(command: StartSessionCommand): Promise<RecommendSession>;
   createStep(command: AddStepCommand): Promise<RecommendSessionStep>;
   createResult(command: CreateResultCommand): Promise<RecommendSessionResult>;
   updateAnswer(stepId: number, answer: string): Promise<void>;

--- a/src/application/port/out/RecommendSessionDbCommandPort.ts
+++ b/src/application/port/out/RecommendSessionDbCommandPort.ts
@@ -9,6 +9,7 @@ export class AddStepCommand {
   sessionId: string;
   question: string;
   options: string[];
+  optionImages?: string[];
 }
 
 export class CreateResultCommand {

--- a/src/application/service/recommend-session.service.spec.ts
+++ b/src/application/service/recommend-session.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { RecommendSessionService } from './recommend-session.service';
 import {
+  commonQuestionMockData,
   recommendSessionMockData,
   recommendSessionResultMockData,
   recommendSessionStepMockData,
@@ -10,8 +11,13 @@ import { RecommendSession, RecommendSessionStep } from '../../domain/recommend-s
 import {
   RecommendSessionNotFoundException,
   RecommendSessionAlreadyEndedException,
+  RecommendSessionInvalidAnswerException,
 } from '../common/error/exception/recommend-session.exception';
-import { SubmitAnswerCommand } from '../port/in/recommend-session/RecommendSessionUseCase';
+import {
+  StartSessionCommand,
+  SubmitAnswerCommand,
+} from '../port/in/recommend-session/RecommendSessionUseCase';
+import { CommonQuestionDbQueryPort } from '../port/out/CommonQuestionDbQueryPort';
 import { RecommendSessionDbCommandPort } from '../port/out/RecommendSessionDbCommandPort';
 import { RecommendSessionDbQueryPort } from '../port/out/RecommendSessionDbQueryPort';
 
@@ -19,6 +25,7 @@ describe('RecommendSessionService', () => {
   let service: RecommendSessionService;
   let queryPortMock: jest.Mocked<RecommendSessionDbQueryPort>;
   let commandPortMock: jest.Mocked<RecommendSessionDbCommandPort>;
+  let commonQuestionQueryPortMock: jest.Mocked<CommonQuestionDbQueryPort>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -29,11 +36,17 @@ describe('RecommendSessionService', () => {
           useValue: {
             getSessionById: jest.fn(),
             getLastStep: jest.fn(),
+            startSession: jest.fn(),
             createStep: jest.fn(),
-            createResult: jest.fn(),
             updateAnswer: jest.fn(),
+            createResult: jest.fn(),
             endSession: jest.fn(),
-            createSession: jest.fn(),
+          },
+        },
+        {
+          provide: 'CommonQuestionGateway',
+          useValue: {
+            getCommonQuestionsByStep: jest.fn(),
           },
         },
       ],
@@ -43,6 +56,8 @@ describe('RecommendSessionService', () => {
     queryPortMock = module.get<jest.Mocked<RecommendSessionDbQueryPort>>('RecommendSessionGateway');
     commandPortMock =
       module.get<jest.Mocked<RecommendSessionDbCommandPort>>('RecommendSessionGateway');
+    commonQuestionQueryPortMock =
+      module.get<jest.Mocked<CommonQuestionDbQueryPort>>('CommonQuestionGateway');
   });
 
   it('should be defined', () => {
@@ -57,32 +72,42 @@ describe('RecommendSessionService', () => {
     it('세션을 시작할 수 있다', async () => {
       // given
       const session = recommendSessionMockData;
-      commandPortMock.createSession.mockResolvedValue(session);
+      commandPortMock.startSession.mockResolvedValue(session);
+
+      const commonQuestion = commonQuestionMockData;
+      commonQuestionQueryPortMock.getCommonQuestionsByStep.mockResolvedValue([commonQuestion]);
 
       const step = recommendSessionStepMockData;
       commandPortMock.createStep.mockResolvedValue(step);
 
-      const userId = 1;
+      const command: StartSessionCommand = {
+        userId: 1,
+        receiverName: '홍길동',
+        deviceId: 'deviceId',
+      };
 
       // when
-      const result = await service.startSession(userId);
+      const result = await service.startSession(command);
 
       // then
       expect(result).toEqual(step);
-      expect(commandPortMock.createSession).toHaveBeenCalledWith(userId);
+      expect(commandPortMock.startSession).toHaveBeenCalledWith(command);
       expect(commandPortMock.createStep).toHaveBeenCalledWith({
         sessionId: session.id,
-        question: step.question,
+        question: `${command.receiverName}${step.question}`,
         options: step.options,
       });
     });
   });
 
   describe('submitAnswer', () => {
-    it('마지막 단계가 아닐 때 답변을 제출하면 다음 단계를 반환한다', async () => {
+    it('답변을 제출하면 세번째 질문까지는 이름을 포함한 공통 질문을 반환한다.', async () => {
       // given
       const session = recommendSessionMockData;
       queryPortMock.getSessionById.mockResolvedValue(session);
+
+      const commonQuestion = commonQuestionMockData;
+      commonQuestionQueryPortMock.getCommonQuestionsByStep.mockResolvedValue([commonQuestion]);
 
       const lastStep: RecommendSessionStep = {
         id: 1,
@@ -97,7 +122,58 @@ describe('RecommendSessionService', () => {
         id: 2,
         sessionId: session.id,
         step: 2,
+        question: `${session.receiverName}${commonQuestion.question}`,
+        options: commonQuestion.options,
+      };
+      commandPortMock.createStep.mockResolvedValue(nextStep);
+
+      const command: SubmitAnswerCommand = { sessionId: session.id, answer: '옵션1' };
+
+      // when
+      const result = await service.submitAnswer(command);
+
+      // then
+      expect(result).toEqual(nextStep);
+      expect(queryPortMock.getSessionById).toHaveBeenCalledWith(session.id);
+      expect(queryPortMock.getLastStep).toHaveBeenCalledWith(session.id);
+      expect(commandPortMock.updateAnswer).toHaveBeenCalledWith(lastStep.id, command.answer);
+      expect(commandPortMock.createStep).toHaveBeenCalledWith({
+        sessionId: session.id,
+        question: nextStep.question,
+        options: nextStep.options,
+      });
+      expect(commandPortMock.endSession).not.toHaveBeenCalled();
+      expect(commandPortMock.createResult).not.toHaveBeenCalled();
+    });
+
+    it('답변을 제출하면 네번째 질문에서는 랜덤 공통 질문을 반환한다.', async () => {
+      // given
+      const session = recommendSessionMockData;
+      queryPortMock.getSessionById.mockResolvedValue(session);
+
+      jest.spyOn(Math, 'random').mockReturnValue(0);
+
+      const commonQuestion = { ...commonQuestionMockData, step: 4 };
+      commonQuestionQueryPortMock.getCommonQuestionsByStep.mockResolvedValue([
+        { ...commonQuestion, question: '랜덤 질문1' },
+        { ...commonQuestion, question: '랜덤 질문2' },
+        { ...commonQuestion, question: '랜덤 질문3' },
+      ]);
+
+      const lastStep: RecommendSessionStep = {
+        id: 3,
+        sessionId: session.id,
+        step: 3,
         question: '질문',
+        options: ['옵션1', '옵션2', '옵션3', '옵션4'],
+      };
+      queryPortMock.getLastStep.mockResolvedValue(lastStep);
+
+      const nextStep: RecommendSessionStep = {
+        id: 4,
+        sessionId: session.id,
+        step: 4,
+        question: '랜덤 질문1',
         options: ['옵션1', '옵션2', '옵션3', '옵션4'],
       };
       commandPortMock.createStep.mockResolvedValue(nextStep);
@@ -117,6 +193,50 @@ describe('RecommendSessionService', () => {
         question: nextStep.question,
         options: nextStep.options,
       });
+      expect(commandPortMock.endSession).not.toHaveBeenCalled();
+      expect(commandPortMock.createResult).not.toHaveBeenCalled();
+    });
+
+    it('답변을 제출하면 다섯번째 질문부터는 LLM 질문을 반환한다.', async () => {
+      // given
+      const session = recommendSessionMockData;
+      queryPortMock.getSessionById.mockResolvedValue(session);
+
+      const lastStep: RecommendSessionStep = {
+        id: 4,
+        sessionId: session.id,
+        step: 4,
+        question: '질문',
+        options: ['옵션1', '옵션2', '옵션3', '옵션4'],
+      };
+      queryPortMock.getLastStep.mockResolvedValue(lastStep);
+
+      const nextStep: RecommendSessionStep = {
+        id: 5,
+        sessionId: session.id,
+        step: 5,
+        question: 'LLM 질문',
+        options: ['옵션1', '옵션2', '옵션3', '옵션4'],
+      };
+      commandPortMock.createStep.mockResolvedValue(nextStep);
+
+      const command: SubmitAnswerCommand = { sessionId: session.id, answer: '옵션1' };
+
+      // when
+      const result = await service.submitAnswer(command);
+
+      // then
+      expect(result).toEqual(nextStep);
+      expect(queryPortMock.getSessionById).toHaveBeenCalledWith(session.id);
+      expect(queryPortMock.getLastStep).toHaveBeenCalledWith(session.id);
+      expect(commandPortMock.updateAnswer).toHaveBeenCalledWith(lastStep.id, command.answer);
+      expect(commandPortMock.createStep).toHaveBeenCalledWith({
+        sessionId: session.id,
+        question: nextStep.question,
+        options: nextStep.options,
+      });
+      expect(commandPortMock.endSession).not.toHaveBeenCalled();
+      expect(commandPortMock.createResult).not.toHaveBeenCalled();
     });
 
     it('마지막 단계에서 답변을 제출하면 추천 결과를 반환한다', async () => {
@@ -126,9 +246,9 @@ describe('RecommendSessionService', () => {
       queryPortMock.getSessionById.mockResolvedValue(session);
 
       const lastStep: RecommendSessionStep = {
-        id: 4,
+        id: 8,
         sessionId,
-        step: 4,
+        step: 8,
         question: '질문',
         options: ['옵션1', '옵션2', '옵션3', '옵션4'],
       };
@@ -144,15 +264,49 @@ describe('RecommendSessionService', () => {
 
       // then
       expect(submitResult).toEqual(result);
+      expect(queryPortMock.getSessionById).toHaveBeenCalledTimes(1);
       expect(queryPortMock.getSessionById).toHaveBeenCalledWith(session.id);
+      expect(queryPortMock.getLastStep).toHaveBeenCalledTimes(1);
       expect(queryPortMock.getLastStep).toHaveBeenCalledWith(session.id);
+      expect(commandPortMock.updateAnswer).toHaveBeenCalledTimes(1);
       expect(commandPortMock.updateAnswer).toHaveBeenCalledWith(lastStep.id, command.answer);
+      expect(commandPortMock.endSession).toHaveBeenCalledTimes(1);
       expect(commandPortMock.endSession).toHaveBeenCalledWith(session.id);
+      expect(commandPortMock.createResult).toHaveBeenCalledTimes(1);
       expect(commandPortMock.createResult).toHaveBeenCalledWith({
         sessionId: session.id,
         recommendProductIds: result.recommendProductIds,
         recommendText: result.recommendText,
       });
+      expect(commandPortMock.createStep).not.toHaveBeenCalled();
+    });
+
+    it('유효하지 않은 답변을 제출하면 예외가 발생한다', async () => {
+      // given
+      const sessionId = 'session-id';
+      const session = recommendSessionMockData;
+      queryPortMock.getSessionById.mockResolvedValue(session);
+
+      const lastStep: RecommendSessionStep = {
+        id: 1,
+        sessionId,
+        step: 1,
+        question: '질문',
+        options: ['옵션1', '옵션2', '옵션3', '옵션4'],
+      };
+      queryPortMock.getLastStep.mockResolvedValue(lastStep);
+
+      // when & then
+      await expect(service.submitAnswer({ sessionId, answer: '옵션5' })).rejects.toThrow(
+        new RecommendSessionInvalidAnswerException(),
+      );
+      expect(queryPortMock.getSessionById).toHaveBeenCalledTimes(1);
+      expect(queryPortMock.getSessionById).toHaveBeenCalledWith(sessionId);
+      expect(queryPortMock.getLastStep).toHaveBeenCalledTimes(1);
+      expect(queryPortMock.getLastStep).toHaveBeenCalledWith(sessionId);
+      expect(commandPortMock.updateAnswer).not.toHaveBeenCalled();
+      expect(commandPortMock.endSession).not.toHaveBeenCalled();
+      expect(commandPortMock.createResult).not.toHaveBeenCalled();
     });
 
     it('존재하지 않는 세션에 답변을 제출하면 예외가 발생한다', async () => {
@@ -164,8 +318,12 @@ describe('RecommendSessionService', () => {
       await expect(service.submitAnswer({ sessionId, answer: '옵션1' })).rejects.toThrow(
         new RecommendSessionNotFoundException(),
       );
+      expect(queryPortMock.getSessionById).toHaveBeenCalledTimes(1);
       expect(queryPortMock.getSessionById).toHaveBeenCalledWith(sessionId);
       expect(commandPortMock.updateAnswer).not.toHaveBeenCalled();
+      expect(commandPortMock.createStep).not.toHaveBeenCalled();
+      expect(commandPortMock.createResult).not.toHaveBeenCalled();
+      expect(commandPortMock.endSession).not.toHaveBeenCalled();
     });
 
     it('이미 종료된 세션에 답변을 제출하면 예외가 발생한다', async () => {
@@ -175,6 +333,7 @@ describe('RecommendSessionService', () => {
         id: sessionId,
         steps: [],
         endedAt: new Date(),
+        receiverName: 'receiverName',
       };
       queryPortMock.getSessionById.mockResolvedValue(session);
 
@@ -182,8 +341,12 @@ describe('RecommendSessionService', () => {
       await expect(service.submitAnswer({ sessionId, answer: '옵션1' })).rejects.toThrow(
         new RecommendSessionAlreadyEndedException(),
       );
+      expect(queryPortMock.getSessionById).toHaveBeenCalledTimes(1);
       expect(queryPortMock.getSessionById).toHaveBeenCalledWith(sessionId);
+      expect(queryPortMock.getLastStep).not.toHaveBeenCalled();
       expect(commandPortMock.updateAnswer).not.toHaveBeenCalled();
+      expect(commandPortMock.endSession).not.toHaveBeenCalled();
+      expect(commandPortMock.createResult).not.toHaveBeenCalled();
     });
   });
 

--- a/src/application/service/recommend-session.service.spec.ts
+++ b/src/application/service/recommend-session.service.spec.ts
@@ -101,7 +101,7 @@ describe('RecommendSessionService', () => {
   });
 
   describe('submitAnswer', () => {
-    it('답변을 제출하면 세번째 질문까지는 이름을 포함한 공통 질문을 반환한다.', async () => {
+    it('답변을 제출하면 네번째 질문까지는 이름을 포함한 공통 질문을 반환한다.', async () => {
       // given
       const session = recommendSessionMockData;
       queryPortMock.getSessionById.mockResolvedValue(session);
@@ -146,7 +146,7 @@ describe('RecommendSessionService', () => {
       expect(commandPortMock.createResult).not.toHaveBeenCalled();
     });
 
-    it('답변을 제출하면 네번째 질문에서는 랜덤 공통 질문을 반환한다.', async () => {
+    it('답변을 제출하면 다섯번째 질문에서는 랜덤 공통 질문을 반환한다.', async () => {
       // given
       const session = recommendSessionMockData;
       queryPortMock.getSessionById.mockResolvedValue(session);
@@ -161,18 +161,18 @@ describe('RecommendSessionService', () => {
       ]);
 
       const lastStep: RecommendSessionStep = {
-        id: 3,
+        id: 4,
         sessionId: session.id,
-        step: 3,
+        step: 4,
         question: '질문',
         options: ['옵션1', '옵션2', '옵션3', '옵션4'],
       };
       queryPortMock.getLastStep.mockResolvedValue(lastStep);
 
       const nextStep: RecommendSessionStep = {
-        id: 4,
+        id: 5,
         sessionId: session.id,
-        step: 4,
+        step: 5,
         question: '랜덤 질문1',
         options: ['옵션1', '옵션2', '옵션3', '옵션4'],
       };
@@ -197,24 +197,24 @@ describe('RecommendSessionService', () => {
       expect(commandPortMock.createResult).not.toHaveBeenCalled();
     });
 
-    it('답변을 제출하면 다섯번째 질문부터는 LLM 질문을 반환한다.', async () => {
+    it('답변을 제출하면 여섯번째 질문부터는 LLM 질문을 반환한다.', async () => {
       // given
       const session = recommendSessionMockData;
       queryPortMock.getSessionById.mockResolvedValue(session);
 
       const lastStep: RecommendSessionStep = {
-        id: 4,
+        id: 5,
         sessionId: session.id,
-        step: 4,
+        step: 5,
         question: '질문',
         options: ['옵션1', '옵션2', '옵션3', '옵션4'],
       };
       queryPortMock.getLastStep.mockResolvedValue(lastStep);
 
       const nextStep: RecommendSessionStep = {
-        id: 5,
+        id: 6,
         sessionId: session.id,
-        step: 5,
+        step: 6,
         question: 'LLM 질문',
         options: ['옵션1', '옵션2', '옵션3', '옵션4'],
       };

--- a/src/application/service/recommend-session.service.ts
+++ b/src/application/service/recommend-session.service.ts
@@ -3,37 +3,41 @@ import { Inject, Injectable } from '@nestjs/common';
 import { RecommendSessionResult, RecommendSessionStep } from '../../domain/recommend-session';
 import {
   RecommendSessionAlreadyEndedException,
+  RecommendSessionInvalidAnswerException,
   RecommendSessionNotFoundException,
 } from '../common/error/exception/recommend-session.exception';
 import {
   RecommendSessionUseCase,
+  StartSessionCommand,
   SubmitAnswerCommand,
 } from '../port/in/recommend-session/RecommendSessionUseCase';
+import { CommonQuestionDbQueryPort } from '../port/out/CommonQuestionDbQueryPort';
 import { RecommendSessionDbCommandPort } from '../port/out/RecommendSessionDbCommandPort';
 import { RecommendSessionDbQueryPort } from '../port/out/RecommendSessionDbQueryPort';
 
 @Injectable()
 export class RecommendSessionService implements RecommendSessionUseCase {
-  private readonly lastStep = 4;
-
   constructor(
     @Inject('RecommendSessionGateway')
     private readonly sessionDbQueryPort: RecommendSessionDbQueryPort,
     @Inject('RecommendSessionGateway')
     private readonly sessionDbCommandPort: RecommendSessionDbCommandPort,
+    @Inject('CommonQuestionGateway')
+    private readonly commonQuestionDbQueryPort: CommonQuestionDbQueryPort,
   ) {}
 
-  async startSession(userId?: number): Promise<RecommendSessionStep> {
-    const session = await this.sessionDbCommandPort.createSession(userId);
+  async startSession(command: StartSessionCommand): Promise<RecommendSessionStep> {
+    const session = await this.sessionDbCommandPort.startSession(command);
 
-    // TODO: LLM 통해 생성하도록 변경
-    const generatedQuestion = '질문';
-    const generatedOptions = ['옵션1', '옵션2', '옵션3', '옵션4'];
+    const commonQuestions = await this.commonQuestionDbQueryPort.getCommonQuestionsByStep(1);
+    const commonQuestion = commonQuestions[0];
+    const question = `${session.receiverName}${commonQuestion.question}`;
+    const options = commonQuestion.options;
 
     return this.sessionDbCommandPort.createStep({
       sessionId: session.id,
-      question: generatedQuestion,
-      options: generatedOptions,
+      question,
+      options,
     });
   }
 
@@ -41,7 +45,6 @@ export class RecommendSessionService implements RecommendSessionUseCase {
     command: SubmitAnswerCommand,
   ): Promise<RecommendSessionStep | RecommendSessionResult> {
     const session = await this.sessionDbQueryPort.getSessionById(command.sessionId);
-
     if (!session) {
       throw new RecommendSessionNotFoundException();
     } else if (session.endedAt) {
@@ -49,31 +52,84 @@ export class RecommendSessionService implements RecommendSessionUseCase {
     }
 
     const lastStep = await this.sessionDbQueryPort.getLastStep(command.sessionId);
-    await this.sessionDbCommandPort.updateAnswer(lastStep.id, command.answer);
-
-    if (lastStep.step === this.lastStep) {
-      // TODO: LLM 통해 생성하도록 변경
-      const generatedRecommendProductIds = [1, 2, 3];
-      const generatedRecommendText = '추천 결과';
-
-      await this.sessionDbCommandPort.endSession(session.id);
-
-      return this.sessionDbCommandPort.createResult({
-        sessionId: session.id,
-        recommendProductIds: generatedRecommendProductIds,
-        recommendText: generatedRecommendText,
-      });
+    if (!lastStep.options.some(option => option === command.answer)) {
+      throw new RecommendSessionInvalidAnswerException();
     }
 
-    // TODO: LLM 통해 생성하도록 변경
-    const generatedQuestion = '질문';
-    const generatedOptions = ['옵션1', '옵션2', '옵션3', '옵션4'];
+    await this.sessionDbCommandPort.updateAnswer(lastStep.id, command.answer);
 
+    const nextStep = lastStep.step + 1;
+    if (nextStep > 8) {
+      return this.generateAnswer(command.sessionId);
+    }
+
+    return this.generateNextStep(command.sessionId, session.receiverName, nextStep);
+  }
+
+  private async generateNextStep(sessionId: string, receiverName: string, step: number) {
+    switch (step) {
+      case 1:
+      case 2:
+      case 3:
+        return this.generateCommonQuestion(sessionId, receiverName, step);
+      case 4:
+        return this.generateRandomCommonQuestion(sessionId, step);
+      default:
+        return this.generateLLMQuestion(sessionId);
+    }
+  }
+
+  private async generateCommonQuestion(
+    sessionId: string,
+    receiverName: string,
+    step: number,
+  ): Promise<RecommendSessionStep> {
+    const commonQuestions = await this.commonQuestionDbQueryPort.getCommonQuestionsByStep(step);
+    const commonQuestion = commonQuestions[0];
     return this.sessionDbCommandPort.createStep({
-      sessionId: session.id,
+      sessionId,
+      question: `${receiverName}${commonQuestion.question}`,
+      options: commonQuestion.options,
+    });
+  }
+
+  private async generateRandomCommonQuestion(
+    sessionId: string,
+    step: number,
+  ): Promise<RecommendSessionStep> {
+    const commonQuestions = await this.commonQuestionDbQueryPort.getCommonQuestionsByStep(step);
+    const selectedQuestion = commonQuestions[Math.floor(Math.random() * commonQuestions.length)];
+    return this.sessionDbCommandPort.createStep({
+      sessionId,
+      question: selectedQuestion.question,
+      options: selectedQuestion.options,
+    });
+  }
+
+  private async generateLLMQuestion(sessionId: string): Promise<RecommendSessionStep> {
+    // TODO: LLM 통해 생성하도록 변경
+    const generatedQuestion = 'LLM 질문';
+    const generatedOptions = ['옵션1', '옵션2', '옵션3', '옵션4'];
+    return this.sessionDbCommandPort.createStep({
+      sessionId,
       question: generatedQuestion,
       options: generatedOptions,
     });
+  }
+
+  private async generateAnswer(sessionId: string): Promise<RecommendSessionResult> {
+    // TODO: LLM 통해 생성하도록 변경
+    const generatedRecommendProductIds = [1, 2, 3];
+    const generatedRecommendText = '추천 결과';
+
+    const result = await this.sessionDbCommandPort.createResult({
+      sessionId,
+      recommendProductIds: generatedRecommendProductIds,
+      recommendText: generatedRecommendText,
+    });
+    await this.sessionDbCommandPort.endSession(sessionId);
+
+    return result;
   }
 
   async endSession(sessionId: string): Promise<void> {

--- a/src/application/service/recommend-session.service.ts
+++ b/src/application/service/recommend-session.service.ts
@@ -71,8 +71,9 @@ export class RecommendSessionService implements RecommendSessionUseCase {
       case 1:
       case 2:
       case 3:
-        return this.generateCommonQuestion(sessionId, receiverName, step);
       case 4:
+        return this.generateCommonQuestion(sessionId, receiverName, step);
+      case 5:
         return this.generateRandomCommonQuestion(sessionId, step);
       default:
         return this.generateLLMQuestion(sessionId);

--- a/src/application/service/recommend-session.service.ts
+++ b/src/application/service/recommend-session.service.ts
@@ -72,8 +72,9 @@ export class RecommendSessionService implements RecommendSessionUseCase {
       case 2:
       case 3:
       case 4:
-        return this.generateCommonQuestion(sessionId, receiverName, step);
       case 5:
+        return this.generateCommonQuestion(sessionId, receiverName, step);
+      case 6:
         return this.generateRandomCommonQuestion(sessionId, step);
       default:
         return this.generateLLMQuestion(sessionId);
@@ -91,6 +92,7 @@ export class RecommendSessionService implements RecommendSessionUseCase {
       sessionId,
       question: `${receiverName}${commonQuestion.question}`,
       options: commonQuestion.options,
+      optionImages: commonQuestion.optionImages,
     });
   }
 

--- a/src/domain/common-question.ts
+++ b/src/domain/common-question.ts
@@ -2,4 +2,5 @@ export class CommonQuestion {
   step: number;
   question: string;
   options: string[];
+  optionImages?: string[];
 }

--- a/src/domain/recommend-session.ts
+++ b/src/domain/recommend-session.ts
@@ -1,5 +1,6 @@
 export class RecommendSession {
   id: string;
+  receiverName: string;
   steps: RecommendSessionStep[];
   result?: RecommendSessionResult;
   endedAt?: Date;

--- a/src/domain/recommend-session.ts
+++ b/src/domain/recommend-session.ts
@@ -12,6 +12,7 @@ export class RecommendSessionStep {
   step: number;
   question: string;
   options: string[];
+  optionImages?: string[];
   answer?: string;
 }
 


### PR DESCRIPTION
# 개요
- 공통 질문 및 답변 검증을 추가했습니다.

# 상세
- 스텝 1-4에서는 선물하고자 하는 분의 이름과 함께 공통 질문을 반환합니다.
- 스텝 5에서는 존재하는 공통질문을 랜덤하게 반환합니다.
- 스텝 6부터는 LLM 생성 질문을 반환합니다. (LLM 생성은 아직 미구현)
- 디바이스 ID와 선물하고자 하는 대상(receiverName) 필드를 추가했습니다.
- step에 option images필드를 추가했습니다.
- 이전 step에서 제공한 선택지에 해당하는 답변을 제공하지 않은 경우 bad request에러를 반환합니다.
- recommend session service의 로직을 리팩터링했습니다.

<img width="895" alt="image" src="https://github.com/user-attachments/assets/9a222ef3-371e-45fb-9bde-3b6110f93d29" />