### PR TITLE
feat: 커스텀 질문을 위한 도메인 추가 및 적용

### DIFF
--- a/src/__mock__/recommend-session.mock.ts
+++ b/src/__mock__/recommend-session.mock.ts
@@ -1,8 +1,8 @@
 import { productMockData } from './product.mock';
 import {
   RecommendSession,
+  RecommendSessionBaseStep,
   RecommendSessionResult,
-  RecommendSessionStep,
 } from '../domain/recommend-session';
 
 export const recommendSessionMockData: Readonly<RecommendSession> = {
@@ -13,7 +13,7 @@ export const recommendSessionMockData: Readonly<RecommendSession> = {
   endedAt: undefined,
 };
 
-export const recommendSessionStepMockData: Readonly<RecommendSessionStep> = {
+export const recommendSessionStepMockData: Readonly<RecommendSessionBaseStep> = {
   id: 1,
   sessionId: 'recommend-session-uuid-v7',
   step: 1,

--- a/src/adapter/db/recommend-session.gateway.ts
+++ b/src/adapter/db/recommend-session.gateway.ts
@@ -8,8 +8,8 @@ import { RecommendSessionStepDbEntity } from './recommend-session-step.entity';
 import { RecommendSessionDbEntity } from './recommend-session.entity';
 import {
   mapToRecommendSession,
+  mapToRecommendSessionBaseStep,
   mapToRecommendSessionResult,
-  mapToRecommendSessionStep,
 } from './recommend-session.mapper';
 import { ProductNotFoundException } from '../../application/common/error/exception/product.exception';
 import { StartSessionCommand } from '../../application/port/in/recommend-session/RecommendSessionUseCase';
@@ -21,8 +21,8 @@ import {
 import { RecommendSessionDbQueryPort } from '../../application/port/out/RecommendSessionDbQueryPort';
 import {
   RecommendSession,
+  RecommendSessionBaseStep,
   RecommendSessionResult,
-  RecommendSessionStep,
 } from '../../domain/recommend-session';
 
 @Injectable()
@@ -46,7 +46,7 @@ export class RecommendSessionGateway
     return mapToRecommendSession(session);
   }
 
-  async getLastStep(sessionId: string): Promise<RecommendSessionStep> {
+  async getLastStep(sessionId: string): Promise<RecommendSessionBaseStep> {
     const stepEntity = await this.stepRepository.findOne(
       { session: { id: sessionId } },
       { orderBy: { step: 'DESC' } },
@@ -54,7 +54,7 @@ export class RecommendSessionGateway
     if (!stepEntity) {
       throw new NotFoundException();
     }
-    return mapToRecommendSessionStep(stepEntity);
+    return mapToRecommendSessionBaseStep(stepEntity);
   }
 
   async startSession(command: StartSessionCommand): Promise<RecommendSession> {
@@ -67,7 +67,7 @@ export class RecommendSessionGateway
     return mapToRecommendSession(sessionEntity);
   }
 
-  async createStep(command: AddStepCommand): Promise<RecommendSessionStep> {
+  async createStep(command: AddStepCommand): Promise<RecommendSessionBaseStep> {
     const session = await this.sessionRepository.findOne(command.sessionId, {
       populate: ['steps'],
     });
@@ -85,12 +85,11 @@ export class RecommendSessionGateway
     stepEntity.step = lastStep ? lastStep.step + 1 : 1;
     stepEntity.question = command.question;
     stepEntity.options = command.options;
-    stepEntity.optionImages = command.optionImages;
 
     session.steps?.add(stepEntity);
     await this.em.persistAndFlush(session);
 
-    return mapToRecommendSessionStep(stepEntity);
+    return mapToRecommendSessionBaseStep(stepEntity);
   }
 
   async createResult(command: CreateResultCommand): Promise<RecommendSessionResult[]> {

--- a/src/adapter/db/recommend-session.mapper.ts
+++ b/src/adapter/db/recommend-session.mapper.ts
@@ -4,8 +4,8 @@ import { RecommendSessionStepDbEntity } from './recommend-session-step.entity';
 import { RecommendSessionDbEntity } from './recommend-session.entity';
 import {
   RecommendSession,
+  RecommendSessionBaseStep,
   RecommendSessionResult,
-  RecommendSessionStep,
 } from '../../domain/recommend-session';
 
 export const mapToRecommendSession = (dbEntity: RecommendSessionDbEntity): RecommendSession => {
@@ -14,23 +14,22 @@ export const mapToRecommendSession = (dbEntity: RecommendSessionDbEntity): Recom
     receiverName: dbEntity.receiverName,
     steps:
       dbEntity.steps && dbEntity.steps.length > 0
-        ? dbEntity.steps.map(step => mapToRecommendSessionStep(step))
+        ? dbEntity.steps.map(step => mapToRecommendSessionBaseStep(step))
         : [],
     result: dbEntity.result ? mapToRecommendSessionResult(dbEntity.result) : undefined,
     endedAt: dbEntity.endedAt ?? undefined,
   };
 };
 
-export const mapToRecommendSessionStep = (
+export const mapToRecommendSessionBaseStep = (
   dbEntity: RecommendSessionStepDbEntity,
-): RecommendSessionStep => {
+): RecommendSessionBaseStep => {
   return {
     id: dbEntity.id,
     sessionId: dbEntity.session.id,
     step: dbEntity.step,
     question: dbEntity.question,
     options: dbEntity.options,
-    optionImages: dbEntity.optionImages,
     answer: dbEntity.answer,
   };
 };

--- a/src/application/port/in/recommend-session/RecommendSessionUseCase.ts
+++ b/src/application/port/in/recommend-session/RecommendSessionUseCase.ts
@@ -1,7 +1,10 @@
 import { IsString } from 'class-validator';
 
 import { SwaggerDto } from '../../../../common/decorators/swagger-dto.decorator';
-import { RecommendSessionResult, RecommendSessionStep } from '../../../../domain/recommend-session';
+import {
+  RecommendSessionStep,
+  RecommendSessionStepResponse,
+} from '../../../../domain/recommend-session';
 
 @SwaggerDto()
 export class StartSessionRequest {
@@ -28,8 +31,6 @@ export class SubmitAnswerCommand extends SubmitAnswerRequest {
 
 export interface RecommendSessionUseCase {
   startSession(command: StartSessionCommand): Promise<RecommendSessionStep>;
-  submitAnswer(
-    command: SubmitAnswerCommand,
-  ): Promise<RecommendSessionStep | RecommendSessionResult[]>;
+  submitAnswer(command: SubmitAnswerCommand): Promise<RecommendSessionStepResponse>;
   endSession(sessionId: string): Promise<void>;
 }

--- a/src/application/port/out/RecommendSessionDbCommandPort.ts
+++ b/src/application/port/out/RecommendSessionDbCommandPort.ts
@@ -1,7 +1,7 @@
 import {
   RecommendSession,
+  RecommendSessionBaseStep,
   RecommendSessionResult,
-  RecommendSessionStep,
 } from '../../../domain/recommend-session';
 import { StartSessionCommand } from '../in/recommend-session/RecommendSessionUseCase';
 
@@ -9,7 +9,6 @@ export class AddStepCommand {
   sessionId: string;
   question: string;
   options: string[];
-  optionImages?: string[];
 }
 
 export class CreateResultCommand {
@@ -24,7 +23,7 @@ export class CreateResultCommand {
 
 export interface RecommendSessionDbCommandPort {
   startSession(command: StartSessionCommand): Promise<RecommendSession>;
-  createStep(command: AddStepCommand): Promise<RecommendSessionStep>;
+  createStep(command: AddStepCommand): Promise<RecommendSessionBaseStep>;
   createResult(command: CreateResultCommand): Promise<RecommendSessionResult[]>;
   updateAnswer(stepId: number, answer: string): Promise<void>;
   endSession(sessionId: string): Promise<void>;

--- a/src/application/port/out/RecommendSessionDbQueryPort.ts
+++ b/src/application/port/out/RecommendSessionDbQueryPort.ts
@@ -1,6 +1,6 @@
-import { RecommendSession, RecommendSessionStep } from '../../../domain/recommend-session';
+import { RecommendSession, RecommendSessionBaseStep } from '../../../domain/recommend-session';
 
 export interface RecommendSessionDbQueryPort {
   getSessionById(sessionId: string): Promise<RecommendSession>;
-  getLastStep(sessionId: string): Promise<RecommendSessionStep>;
+  getLastStep(sessionId: string): Promise<RecommendSessionBaseStep>;
 }

--- a/src/application/service/recommend-session.service.ts
+++ b/src/application/service/recommend-session.service.ts
@@ -243,7 +243,10 @@ export class RecommendSessionService implements RecommendSessionUseCase {
       throw new RecommendProductNotFoundException();
     }
 
-    const llmAnswer = await this.openAiClient.recommendGift(input, recommendProducts);
+    const llmAnswer = await retry(
+      async () => await this.openAiClient.recommendGift(input, recommendProducts),
+      { maxRetries: 3 },
+    );
     const result = await this.sessionDbCommandPort.createResult({
       sessionId,
       recommendResults: llmAnswer.map((answer: { id: number; reason: string }, index: number) => ({

--- a/src/application/service/recommend-session.service.ts
+++ b/src/application/service/recommend-session.service.ts
@@ -4,8 +4,12 @@ import { OpenAiClient } from '../../adapter/llm/openai.client';
 import { retry } from '../../common/util/retry.util';
 import {
   RecommendSession,
+  RecommendSessionFirstStep,
+  RecommendSessionOccasionStep,
   RecommendSessionResult,
   RecommendSessionStep,
+  RecommendSessionStepResponse,
+  RecommendSessionStepType,
 } from '../../domain/recommend-session';
 import {
   RecommendProductNotFoundException,
@@ -25,6 +29,28 @@ import { RecommendSessionDbQueryPort } from '../port/out/RecommendSessionDbQuery
 
 @Injectable()
 export class RecommendSessionService implements RecommendSessionUseCase {
+  private readonly STEP_COUNT = {
+    setupCount: 4,
+    occasionCount: 1,
+    questionCount: 4,
+  };
+
+  private readonly optionMap = {
+    ['생일 축하']: { key: 'birthday', title: '생일 축하', description: '님의 생일이에요' },
+    ['고마워요']: { key: 'thankyou', title: '고마워요', description: '님께 고마운 마음이에요' },
+    ['축하해요']: {
+      key: 'congratulation',
+      title: '축하해요',
+      description: '님께 기쁜 마음을 전해요',
+    },
+    ['응원해요']: { key: 'support', title: '응원해요', description: '님을 응원해요' },
+    ['미안한 마음']: {
+      key: 'sorry',
+      title: '미안한 마음',
+      description: '님께 미안한 마음을 전해요',
+    },
+  };
+
   constructor(
     @Inject('CommonQuestionGateway')
     private readonly commonQuestionDbQueryPort: CommonQuestionDbQueryPort,
@@ -38,7 +64,7 @@ export class RecommendSessionService implements RecommendSessionUseCase {
     private readonly openAiClient: OpenAiClient,
   ) {}
 
-  async startSession(command: StartSessionCommand): Promise<RecommendSessionStep> {
+  async startSession(command: StartSessionCommand): Promise<RecommendSessionFirstStep> {
     const session = await this.sessionDbCommandPort.startSession(command);
 
     const commonQuestions = await this.commonQuestionDbQueryPort.getCommonQuestionsByStep(1);
@@ -46,16 +72,21 @@ export class RecommendSessionService implements RecommendSessionUseCase {
     const question = `${session.receiverName}${commonQuestion.question}`;
     const options = commonQuestion.options;
 
-    return this.sessionDbCommandPort.createStep({
+    const recommendSessionStep = await this.sessionDbCommandPort.createStep({
       sessionId: session.id,
       question,
       options,
     });
+
+    return {
+      ...recommendSessionStep,
+      ...this.STEP_COUNT,
+      type: RecommendSessionStepType.SETUP,
+      sessionId: session.id,
+    };
   }
 
-  async submitAnswer(
-    command: SubmitAnswerCommand,
-  ): Promise<RecommendSessionStep | RecommendSessionResult[]> {
+  async submitAnswer(command: SubmitAnswerCommand): Promise<RecommendSessionStepResponse> {
     const session = await this.sessionDbQueryPort.getSessionById(command.sessionId);
     if (!session) {
       throw new RecommendSessionNotFoundException();
@@ -78,14 +109,19 @@ export class RecommendSessionService implements RecommendSessionUseCase {
     return this.generateNextStep(command.sessionId, session.receiverName, nextStep);
   }
 
-  private async generateNextStep(sessionId: string, receiverName: string, step: number) {
+  private async generateNextStep(
+    sessionId: string,
+    receiverName: string,
+    step: number,
+  ): Promise<RecommendSessionStep | RecommendSessionOccasionStep> {
     switch (step) {
       case 1:
       case 2:
       case 3:
       case 4:
-      case 5:
         return this.generateCommonQuestion(sessionId, receiverName, step);
+      case 5:
+        return this.generateOccasionQuestion(sessionId, receiverName, step);
       case 6:
         return this.generateRandomCommonQuestion(sessionId, step);
       default:
@@ -100,12 +136,42 @@ export class RecommendSessionService implements RecommendSessionUseCase {
   ): Promise<RecommendSessionStep> {
     const commonQuestions = await this.commonQuestionDbQueryPort.getCommonQuestionsByStep(step);
     const commonQuestion = commonQuestions[0];
-    return this.sessionDbCommandPort.createStep({
+    const recommendSessionStep = await this.sessionDbCommandPort.createStep({
       sessionId,
       question: `${receiverName}${commonQuestion.question}`,
       options: commonQuestion.options,
-      optionImages: commonQuestion.optionImages,
     });
+
+    return { ...recommendSessionStep, type: RecommendSessionStepType.SETUP };
+  }
+
+  private async generateOccasionQuestion(
+    sessionId: string,
+    receiverName: string,
+    step: number,
+  ): Promise<RecommendSessionOccasionStep> {
+    const commonQuestions = await this.commonQuestionDbQueryPort.getCommonQuestionsByStep(step);
+    const commonQuestion = commonQuestions[0];
+    const recommendSessionStep = await this.sessionDbCommandPort.createStep({
+      sessionId,
+      question: `${receiverName}${commonQuestion.question}`,
+      options: commonQuestion.options,
+    });
+
+    const options = commonQuestion.options
+      .map(option => this.optionMap[option as keyof typeof this.optionMap])
+      .map(option => ({
+        key: option.key,
+        title: option.title,
+        description: `${receiverName}${option.description}`,
+      }));
+
+    return {
+      ...recommendSessionStep,
+      type: RecommendSessionStepType.OCCASION,
+      description: '선물을 주고자 하는 상황을 알려주세요',
+      options,
+    };
   }
 
   private async generateRandomCommonQuestion(
@@ -114,11 +180,16 @@ export class RecommendSessionService implements RecommendSessionUseCase {
   ): Promise<RecommendSessionStep> {
     const commonQuestions = await this.commonQuestionDbQueryPort.getCommonQuestionsByStep(step);
     const selectedQuestion = commonQuestions[Math.floor(Math.random() * commonQuestions.length)];
-    return this.sessionDbCommandPort.createStep({
+    const recommendSessionStep = await this.sessionDbCommandPort.createStep({
       sessionId,
       question: selectedQuestion.question,
       options: selectedQuestion.options,
     });
+
+    return {
+      ...recommendSessionStep,
+      type: RecommendSessionStepType.QUESTION,
+    };
   }
 
   private async generateLLMQuestion(sessionId: string): Promise<RecommendSessionStep> {
@@ -128,7 +199,15 @@ export class RecommendSessionService implements RecommendSessionUseCase {
     const generateQuestion = async () => await this.openAiClient.generateQuestion(input);
     const llmQuestion = await retry(generateQuestion, { maxRetries: 3 });
 
-    return this.sessionDbCommandPort.createStep({ sessionId, ...llmQuestion });
+    const recommendSessionStep = await this.sessionDbCommandPort.createStep({
+      sessionId,
+      ...llmQuestion,
+    });
+
+    return {
+      ...recommendSessionStep,
+      type: RecommendSessionStepType.QUESTION,
+    };
   }
 
   async endSession(sessionId: string): Promise<void> {

--- a/src/domain/recommend-session.ts
+++ b/src/domain/recommend-session.ts
@@ -1,20 +1,64 @@
 import { Product } from './product';
 
+export enum RecommendSessionStepType {
+  SETUP = 'setup',
+  OCCASION = 'occasion',
+  QUESTION = 'question',
+}
+
 export class RecommendSession {
   id: string;
   receiverName: string;
-  steps: RecommendSessionStep[];
+  steps: RecommendSessionBaseStep[];
   result?: RecommendSessionResult;
   endedAt?: Date;
 }
 
-export class RecommendSessionStep {
+export class RecommendSessionFirstStep {
+  type: RecommendSessionStepType.SETUP;
   id: number;
   sessionId: string;
   step: number;
   question: string;
   options: string[];
-  optionImages?: string[];
+  setupCount: number;
+  occasionCount: number;
+  questionCount: number;
+}
+
+export type OccasionOptions = {
+  key: string;
+  title: string;
+  description: string;
+};
+
+export class RecommendSessionBaseStep {
+  id: number;
+  sessionId: string;
+  step: number;
+  question: string;
+  options: string[];
+  answer?: string;
+}
+
+export class RecommendSessionOccasionStep {
+  type: RecommendSessionStepType.OCCASION;
+  id: number;
+  sessionId: string;
+  step: number;
+  question: string;
+  description: string;
+  options: OccasionOptions[];
+  answer?: string;
+}
+
+export class RecommendSessionStep {
+  type: RecommendSessionStepType.SETUP | RecommendSessionStepType.QUESTION;
+  id: number;
+  sessionId: string;
+  step: number;
+  question: string;
+  options: string[];
   answer?: string;
 }
 
@@ -23,3 +67,8 @@ export class RecommendSessionResult {
   reason: string;
   order: number;
 }
+
+export type RecommendSessionStepResponse =
+  | RecommendSessionOccasionStep
+  | RecommendSessionStep
+  | RecommendSessionResult[];


### PR DESCRIPTION
# 개요
- 커스텀 질문을 위한 도메인을 추가하고 적용합니다.

# 상세
- 세션 시작시 질문 타입별 개수를 상수로 반환합니다. (setup 4개, occasion 1개, question 4개)
- 5번째 (ocassion)에서는 UI를 커스텀하기 위한 option 추가 필드와 description을 포함합니다.