### PR TITLE
feat: 추천 세션 연동을 위한 deviceId 인자 추가

### DIFF
--- a/src/adapter/db/recommend-session.gateway.ts
+++ b/src/adapter/db/recommend-session.gateway.ts
@@ -140,4 +140,14 @@ export class RecommendSessionGateway
     session.endedAt = new Date();
     await this.em.persistAndFlush(session);
   }
+
+  async updateSessionOwner(deviceId: string, userId: number): Promise<void> {
+    const session = await this.sessionRepository.findOne({ deviceId });
+    if (!session) {
+      return;
+    }
+
+    session.userId = userId;
+    await this.em.persistAndFlush(session);
+  }
 }

--- a/src/adapter/db/recommend-session.gateway.ts
+++ b/src/adapter/db/recommend-session.gateway.ts
@@ -142,12 +142,6 @@ export class RecommendSessionGateway
   }
 
   async updateSessionOwner(deviceId: string, userId: number): Promise<void> {
-    const session = await this.sessionRepository.findOne({ deviceId });
-    if (!session) {
-      return;
-    }
-
-    session.userId = userId;
-    await this.em.persistAndFlush(session);
+    await this.sessionRepository.nativeUpdate({ deviceId }, { userId });
   }
 }

--- a/src/application/port/in/auth/AuthUseCase.ts
+++ b/src/application/port/in/auth/AuthUseCase.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsNotEmpty, IsString } from 'class-validator';
+import { IsInt, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 import { SwaggerDto } from '../../../../common/decorators/swagger-dto.decorator';
 import { IToken } from '../../../../domain/token';
@@ -25,6 +25,10 @@ export class SocialLoginCommand {
   @IsString()
   @IsNotEmpty()
   profileImageUrl: string;
+
+  @IsOptional()
+  @IsString()
+  deviceId?: string;
 }
 
 @SwaggerDto()

--- a/src/application/port/out/RecommendSessionDbCommandPort.ts
+++ b/src/application/port/out/RecommendSessionDbCommandPort.ts
@@ -27,5 +27,6 @@ export interface RecommendSessionDbCommandPort {
   createStep(command: AddStepCommand): Promise<RecommendSessionBaseStep>;
   createResult(command: CreateResultCommand): Promise<RecommendSessionResult[]>;
   updateAnswer(stepId: number, answer: string): Promise<void>;
+  updateSessionOwner(deviceId: string, userId: number): Promise<void>;
   endSession(sessionId: string): Promise<void>;
 }

--- a/src/application/service/auth.service.spec.ts
+++ b/src/application/service/auth.service.spec.ts
@@ -120,6 +120,33 @@ describe('AuthService', () => {
       expect(recommendSessionCommandPortMock.updateSessionOwner).not.toHaveBeenCalled();
     });
 
+    it('로그인시 deviceId가 있는 경우 세션 소유자를 업데이트한다', async () => {
+      // given
+      const snsId = 'sns-user-1';
+      queryPortMock.getUserBySnsId.mockResolvedValue(userMockData);
+      jwtService.sign.mockReturnValueOnce('accessToken').mockReturnValueOnce('refreshToken');
+
+      const command: SocialLoginCommand = {
+        snsId,
+        nickname: '무시될 유저',
+        profileImageUrl: 'http://irrelevant.com/image.jpg',
+        deviceId: 'device-id-123',
+      };
+
+      // when
+      const result = await service.loginWithSocial(command);
+
+      // then
+      expect(result).toEqual({ accessToken: 'accessToken', refreshToken: 'refreshToken' });
+      expect(queryPortMock.getUserBySnsId).toHaveBeenCalledTimes(1);
+      expect(queryPortMock.getUserBySnsId).toHaveBeenCalledWith(snsId);
+      expect(commandPortMock.createUser).not.toHaveBeenCalled();
+      expect(recommendSessionCommandPortMock.updateSessionOwner).toHaveBeenCalledWith(
+        command.deviceId,
+        userMockData.id,
+      );
+    });
+
     it('회원가입시 deviceId가 있는 경우 세션 소유자를 업데이트한다', async () => {
       // given
       queryPortMock.getUserBySnsId.mockResolvedValueOnce(null);

--- a/src/application/service/auth.service.spec.ts
+++ b/src/application/service/auth.service.spec.ts
@@ -6,6 +6,7 @@ import { userMockData } from '../../__mock__/user.mock';
 import { UserRole } from '../../domain/user';
 import { InvalidRefreshTokenException } from '../common/error/exception';
 import { RefreshTokenCommand, SocialLoginCommand } from '../port/in/auth/AuthUseCase';
+import { RecommendSessionDbCommandPort } from '../port/out/RecommendSessionDbCommandPort';
 import { UserDbCommandPort } from '../port/out/UserDbCommandPort';
 import { UserDbQueryPort } from '../port/out/UserDbQueryPort';
 
@@ -16,6 +17,7 @@ describe('AuthService', () => {
   let jwtService: jest.Mocked<JwtService>;
   let queryPortMock: jest.Mocked<UserDbQueryPort>;
   let commandPortMock: jest.Mocked<UserDbCommandPort>;
+  let recommendSessionCommandPortMock: jest.Mocked<RecommendSessionDbCommandPort>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -36,6 +38,12 @@ describe('AuthService', () => {
             verify: jest.fn(),
           },
         },
+        {
+          provide: 'RecommendSessionGateway',
+          useValue: {
+            updateSessionOwner: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -43,6 +51,8 @@ describe('AuthService', () => {
     jwtService = module.get(JwtService);
     queryPortMock = module.get<jest.Mocked<UserDbQueryPort>>('UserGateway');
     commandPortMock = module.get<jest.Mocked<UserDbCommandPort>>('UserGateway');
+    recommendSessionCommandPortMock =
+      module.get<jest.Mocked<RecommendSessionDbCommandPort>>('RecommendSessionGateway');
   });
 
   it('should be defined', () => {
@@ -64,6 +74,7 @@ describe('AuthService', () => {
         snsId,
         nickname: '무시될 유저',
         profileImageUrl: 'http://irrelevant.com/image.jpg',
+        deviceId: undefined,
       };
 
       // when
@@ -74,12 +85,13 @@ describe('AuthService', () => {
       expect(queryPortMock.getUserBySnsId).toHaveBeenCalledTimes(1);
       expect(queryPortMock.getUserBySnsId).toHaveBeenCalledWith(snsId);
       expect(commandPortMock.createUser).not.toHaveBeenCalled();
+      expect(recommendSessionCommandPortMock.updateSessionOwner).not.toHaveBeenCalled();
     });
+
     it('snsId로 가입한 계정이 없는 경우 회원가입에 성공한다', async () => {
       // given
       queryPortMock.getUserBySnsId.mockResolvedValueOnce(null);
 
-      commandPortMock.createUser.mockResolvedValue(2);
       jwtService.sign.mockReturnValueOnce('accessToken').mockReturnValueOnce('refreshToken');
 
       const newSnsId = 'sns-new-456';
@@ -88,6 +100,7 @@ describe('AuthService', () => {
         snsId: newSnsId,
         nickname: '새로운 유저',
         profileImageUrl: 'http://new.image.jpg',
+        deviceId: undefined,
       };
 
       // when
@@ -103,6 +116,44 @@ describe('AuthService', () => {
           nickname: command.nickname,
           profileImageUrl: command.profileImageUrl,
         }),
+      );
+      expect(recommendSessionCommandPortMock.updateSessionOwner).not.toHaveBeenCalled();
+    });
+
+    it('회원가입시 deviceId가 있는 경우 세션 소유자를 업데이트한다', async () => {
+      // given
+      queryPortMock.getUserBySnsId.mockResolvedValueOnce(null);
+
+      const userId = 2;
+      commandPortMock.createUser.mockResolvedValue(userId);
+      jwtService.sign.mockReturnValueOnce('accessToken').mockReturnValueOnce('refreshToken');
+
+      const newSnsId = 'sns-new-456';
+
+      const command: SocialLoginCommand = {
+        snsId: newSnsId,
+        nickname: '새로운 유저',
+        profileImageUrl: 'http://new.image.jpg',
+        deviceId: 'device-id-123',
+      };
+
+      // when
+      const result = await service.loginWithSocial(command);
+
+      // then
+      expect(result).toEqual({ accessToken: 'accessToken', refreshToken: 'refreshToken' });
+
+      expect(queryPortMock.getUserBySnsId).toHaveBeenCalledWith(command.snsId);
+      expect(commandPortMock.createUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          snsId: command.snsId,
+          nickname: command.nickname,
+          profileImageUrl: command.profileImageUrl,
+        }),
+      );
+      expect(recommendSessionCommandPortMock.updateSessionOwner).toHaveBeenCalledWith(
+        command.deviceId,
+        userId,
       );
     });
   });


### PR DESCRIPTION
# 개요
- 추천 세션 연동을 위한 deviceId 인자를 추가합니다.

# 상세
- 로그인/회원가입시 deviceId를 받도록 인자를 추가했습니다.
- 해당 deviceId와 동일한 UUID가 전달된 경우 로그인/회원가입한 유저의 소유로 추천 세션의 소유자를 할당합니다.