### PR TITLE
feat: 질문 단계 되돌리기

### DIFF
--- a/src/adapter/db/recommend-session-step.entity.ts
+++ b/src/adapter/db/recommend-session-step.entity.ts
@@ -25,6 +25,12 @@ export class RecommendSessionStepDbEntity {
   @Property({ onCreate: () => new Date() })
   createdAt: Date;
 
+  @Property({ onCreate: () => new Date(), onUpdate: () => new Date() })
+  updatedAt: Date;
+
+  @Property({ nullable: true })
+  deletedAt?: Date;
+
   @ManyToOne(() => RecommendSessionDbEntity)
   session: Rel<RecommendSessionDbEntity>;
 }

--- a/src/adapter/web/recommend-session.controller.ts
+++ b/src/adapter/web/recommend-session.controller.ts
@@ -20,7 +20,11 @@ export class RecommendSessionController {
 
   @Post(':sessionId/answer')
   async submitAnswer(@Param('sessionId') sessionId: string, @Body() command: SubmitAnswerRequest) {
-    return this.recommendSessionUseCase.submitAnswer({ sessionId, answer: command.answer });
+    return this.recommendSessionUseCase.submitAnswer({
+      sessionId,
+      answer: command.answer,
+      step: command.step,
+    });
   }
 
   @Delete(':sessionId')

--- a/src/application/common/error/error-messages.ts
+++ b/src/application/common/error/error-messages.ts
@@ -17,5 +17,6 @@ export const ERROR_MESSAGES = {
     NOT_FOUND: '세션을 찾을 수 없습니다.',
     INVALID_ANSWER: '유효하지 않은 답변입니다.',
     PRODUCT_NOT_FOUND: '추천할 상품을 찾을 수 없습니다.',
+    INVALID_STEP: '유효하지 않은 단계입니다.',
   },
 } as const;

--- a/src/application/common/error/exception/recommend-session.exception.ts
+++ b/src/application/common/error/exception/recommend-session.exception.ts
@@ -25,3 +25,9 @@ export class RecommendProductNotFoundException extends NotFoundException {
     super(ERROR_MESSAGES.RECOMMEND_SESSION.PRODUCT_NOT_FOUND);
   }
 }
+
+export class RecommendSessionInvalidStepException extends BadRequestException {
+  constructor() {
+    super(ERROR_MESSAGES.RECOMMEND_SESSION.INVALID_STEP);
+  }
+}

--- a/src/application/port/in/recommend-session/RecommendSessionUseCase.ts
+++ b/src/application/port/in/recommend-session/RecommendSessionUseCase.ts
@@ -1,4 +1,4 @@
-import { IsString } from 'class-validator';
+import { IsInt, IsString, Min } from 'class-validator';
 
 import { SwaggerDto } from '../../../../common/decorators/swagger-dto.decorator';
 import {
@@ -21,6 +21,10 @@ export class StartSessionCommand extends StartSessionRequest {
 
 @SwaggerDto()
 export class SubmitAnswerRequest {
+  @Min(1)
+  @IsInt()
+  step: number;
+
   @IsString()
   answer: string;
 }

--- a/src/application/port/out/RecommendSessionDbCommandPort.ts
+++ b/src/application/port/out/RecommendSessionDbCommandPort.ts
@@ -7,6 +7,7 @@ import { StartSessionCommand } from '../in/recommend-session/RecommendSessionUse
 
 export class AddStepCommand {
   sessionId: string;
+  step: number;
   question: string;
   options: string[];
 }
@@ -29,4 +30,5 @@ export interface RecommendSessionDbCommandPort {
   updateAnswer(stepId: number, answer: string): Promise<void>;
   updateSessionOwner(deviceId: string, userId: number): Promise<void>;
   endSession(sessionId: string): Promise<void>;
+  removeProgressedSteps(sessionId: string, step: number): Promise<void>;
 }


### PR DESCRIPTION
# 개요
- 질문 단계 되돌릴수 있도록 이전 단계에 답변하는 기능을 추가합니다.

# 상세
- 이전 질문으로 돌아가 답변을 등록할 수 있도록 step을 인자로 받아 이전 step의 인자가 넘어온 경우 해당 이후 단계의 step들은 제거하고, 다시 해당 단계부터 답변할 수 있도록 기능을 추가했습니다.