### PR TITLE
feat: 추천 결과 단건/다건 조회 구현

### DIFF
--- a/src/adapter/db/recommend-session.gateway.ts
+++ b/src/adapter/db/recommend-session.gateway.ts
@@ -34,6 +34,8 @@ export class RecommendSessionGateway
     private readonly sessionRepository: EntityRepository<RecommendSessionDbEntity>,
     @InjectRepository(RecommendSessionStepDbEntity)
     private readonly stepRepository: EntityRepository<RecommendSessionStepDbEntity>,
+    @InjectRepository(RecommendSessionResultDbEntity)
+    private readonly resultRepository: EntityRepository<RecommendSessionResultDbEntity>,
     @Inject(EntityManager)
     private readonly em: EntityManager,
   ) {}
@@ -47,6 +49,26 @@ export class RecommendSessionGateway
       throw new NotFoundException();
     }
     return mapToRecommendSession(session);
+  }
+
+  async getSessionResultsById(sessionId: string): Promise<RecommendSessionResult[]> {
+    const results = await this.resultRepository.find(
+      { session: { id: sessionId } },
+      { populate: ['product'] },
+    );
+    return results.map(mapToRecommendSessionResult);
+  }
+
+  async getSessionResultById(sessionId: string, order: number): Promise<RecommendSessionResult> {
+    const result = await this.resultRepository.findOne(
+      { session: { id: sessionId }, order },
+      { populate: ['product'] },
+    );
+    if (!result) {
+      throw new NotFoundException();
+    }
+
+    return mapToRecommendSessionResult(result);
   }
 
   async getLastStep(sessionId: string): Promise<RecommendSessionBaseStep> {

--- a/src/adapter/web/recommend-session.controller.ts
+++ b/src/adapter/web/recommend-session.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Inject, Post, Delete, Param, Body } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Inject, Param, Post } from '@nestjs/common';
 
 import {
   RecommendSessionUseCase,
@@ -12,6 +12,19 @@ export class RecommendSessionController {
     @Inject('RecommendSessionUseCase')
     private readonly recommendSessionUseCase: RecommendSessionUseCase,
   ) {}
+
+  @Get(':sessionId/result')
+  async getRecommendSessionResults(@Param('sessionId') sessionId: string) {
+    return this.recommendSessionUseCase.getRecommendSessionResults(sessionId);
+  }
+
+  @Get(':sessionId/result/:order')
+  async getRecommendSessionResultOne(
+    @Param('sessionId') sessionId: string,
+    @Param('order') order: number,
+  ) {
+    return this.recommendSessionUseCase.getRecommendSessionResult(sessionId, order);
+  }
 
   @Post()
   async startSession(@Body() command: StartSessionRequest) {

--- a/src/application/port/in/recommend-session/RecommendSessionUseCase.ts
+++ b/src/application/port/in/recommend-session/RecommendSessionUseCase.ts
@@ -2,6 +2,7 @@ import { IsInt, IsString, Min } from 'class-validator';
 
 import { SwaggerDto } from '../../../../common/decorators/swagger-dto.decorator';
 import {
+  RecommendSessionResult,
   RecommendSessionStep,
   RecommendSessionStepResponse,
 } from '../../../../domain/recommend-session';
@@ -34,6 +35,8 @@ export class SubmitAnswerCommand extends SubmitAnswerRequest {
 }
 
 export interface RecommendSessionUseCase {
+  getRecommendSessionResults(sessionId: string): Promise<RecommendSessionResult[]>;
+  getRecommendSessionResult(sessionId: string, order: number): Promise<RecommendSessionResult>;
   startSession(command: StartSessionCommand): Promise<RecommendSessionStep>;
   submitAnswer(command: SubmitAnswerCommand): Promise<RecommendSessionStepResponse>;
   endSession(sessionId: string): Promise<void>;

--- a/src/application/port/out/RecommendSessionDbQueryPort.ts
+++ b/src/application/port/out/RecommendSessionDbQueryPort.ts
@@ -1,6 +1,12 @@
-import { RecommendSession, RecommendSessionBaseStep } from '../../../domain/recommend-session';
+import {
+  RecommendSession,
+  RecommendSessionBaseStep,
+  RecommendSessionResult,
+} from '../../../domain/recommend-session';
 
 export interface RecommendSessionDbQueryPort {
   getSessionById(sessionId: string): Promise<RecommendSession>;
+  getSessionResultsById(sessionId: string): Promise<RecommendSessionResult[]>;
+  getSessionResultById(sessionId: string, order: number): Promise<RecommendSessionResult>;
   getLastStep(sessionId: string): Promise<RecommendSessionBaseStep>;
 }

--- a/src/application/service/recommend-session.service.ts
+++ b/src/application/service/recommend-session.service.ts
@@ -65,6 +65,17 @@ export class RecommendSessionService implements RecommendSessionUseCase {
     private readonly openAiClient: OpenAiClient,
   ) {}
 
+  async getRecommendSessionResults(sessionId: string): Promise<RecommendSessionResult[]> {
+    return this.sessionDbQueryPort.getSessionResultsById(sessionId);
+  }
+
+  async getRecommendSessionResult(
+    sessionId: string,
+    order: number,
+  ): Promise<RecommendSessionResult> {
+    return this.sessionDbQueryPort.getSessionResultById(sessionId, order);
+  }
+
   async startSession(command: StartSessionCommand): Promise<RecommendSessionFirstStep> {
     const session = await this.sessionDbCommandPort.startSession(command);
 

--- a/src/framework/module/auth.module.ts
+++ b/src/framework/module/auth.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import {
   RecommendSessionDbEntity,
+  RecommendSessionResultDbEntity,
   RecommendSessionStepDbEntity,
   UserDbEntity,
 } from 'src/adapter/db';
@@ -20,6 +21,7 @@ import { JwtStrategy } from '../auth/strategy';
       UserDbEntity,
       RecommendSessionDbEntity,
       RecommendSessionStepDbEntity,
+      RecommendSessionResultDbEntity,
     ]),
     JwtModule.registerAsync({
       imports: [ConfigModule],


### PR DESCRIPTION
# 개요
- 추천 결과 단건/다건 조회를 구현합니다.

# 상세
- 다건 조회: `/api/v1/recommend-session/:sessionId/result`
- 단건 조회: `/api/v1/recommend-session/:sessionId/result/:order`