### PR TITLE
feat: 위시리스트 요약/상세 조회 API 및 테스트 코드 추가

### DIFF
--- a/src/__mock__/wishlist.mock.ts
+++ b/src/__mock__/wishlist.mock.ts
@@ -1,0 +1,38 @@
+import { AddWishlistCommand } from 'src/application/port/in/wishlist/WishlistUseCase';
+import { WishlistGroupedByReceiver } from 'src/domain/wishlist';
+
+export const createWishlistMock: Readonly<AddWishlistCommand> = {
+  userId: 1,
+  productId: 101,
+  receiverName: '민수',
+};
+
+export const validWishlistItem = {
+  wishlistId: 1,
+  productId: 101,
+  name: '감성 무드등',
+  imageUrl: 'https://example.com/image.jpg',
+  deleted: false,
+  createdAt: new Date('2025-05-14T12:00:00Z'),
+};
+
+export const deletedWishlistItem = {
+  wishlistId: 2,
+  productId: 999,
+  name: null,
+  imageUrl: null,
+  deleted: true,
+  createdAt: new Date('2025-05-14T12:05:00Z'),
+};
+export const wishlistGroupedMock: WishlistGroupedByReceiver[] = [
+  {
+    receiverName: '민수',
+    items: [validWishlistItem],
+  },
+];
+export const wishlistGroupedWithDeletedMock: WishlistGroupedByReceiver[] = [
+  {
+    receiverName: '민수',
+    items: [deletedWishlistItem],
+  },
+];

--- a/src/__mock__/wishlist.mock.ts
+++ b/src/__mock__/wishlist.mock.ts
@@ -1,5 +1,5 @@
 import { AddWishlistCommand } from 'src/application/port/in/wishlist/WishlistUseCase';
-import { Wishlist, WishlistGroupedByReceiver, WishlistSummary } from 'src/domain/wishlist';
+import { Wishlist, WishlistItem, WishlistSummary } from 'src/domain/wishlist';
 
 export const createWishlistMock: Readonly<AddWishlistCommand> = {
   userId: 1,
@@ -7,23 +7,6 @@ export const createWishlistMock: Readonly<AddWishlistCommand> = {
   receiverName: '민수',
 };
 
-export const validWishlistItem = {
-  wishlistId: 1,
-  productId: 101,
-  name: '감성 무드등',
-  imageUrl: 'https://example.com/image.jpg',
-  deleted: false,
-  createdAt: new Date('2025-05-14T12:00:00Z'),
-};
-
-export const deletedWishlistItem = {
-  wishlistId: 2,
-  productId: 999,
-  name: null,
-  imageUrl: null,
-  deleted: true,
-  createdAt: new Date('2025-05-14T12:05:00Z'),
-};
 export const wishlistGroupedMock: WishlistSummary[] = [
   {
     receiverName: '민수',
@@ -31,16 +14,45 @@ export const wishlistGroupedMock: WishlistSummary[] = [
     imageUrls: ['https://example.com/image.jpg'],
   },
 ];
-export const wishlistGroupedWithDeletedMock: WishlistGroupedByReceiver[] = [
+
+export const validWishlistProduct = {
+  id: 101,
+  name: '감성 무드등',
+  imageUrl: 'https://example.com/image.jpg',
+  price: 10000,
+};
+
+export const wishlistDetailMock = [
   {
-    receiverName: '민수',
-    items: [deletedWishlistItem],
+    wishlistId: 1,
+    product: {
+      productId: 101,
+      name: '감성 무드등',
+      price: 10000,
+      imageUrl: 'https://example.com/image.jpg',
+    },
+    deleted: false,
+    createdAt: new Date('2025-05-21T10:00:00Z'),
   },
 ];
+export const wishlistDetailWithDeletedMock: WishlistItem[] = [
+  {
+    wishlistId: 2,
+    product: {
+      productId: 999,
+      name: null,
+      price: null,
+      imageUrl: null,
+    },
+    deleted: true,
+    createdAt: new Date('2025-05-21T10:00:00Z'),
+  },
+];
+
 export const domainWishlistMock: Wishlist = {
   id: 1,
   userId: 1,
   productId: 101,
   receiverName: '민수',
-  createdAt: new Date('2025-05-14T12:00:00Z'),
+  createdAt: new Date('2025-05-21T10:00:00Z'),
 };

--- a/src/__mock__/wishlist.mock.ts
+++ b/src/__mock__/wishlist.mock.ts
@@ -1,5 +1,5 @@
 import { AddWishlistCommand } from 'src/application/port/in/wishlist/WishlistUseCase';
-import { WishlistGroupedByReceiver } from 'src/domain/wishlist';
+import { Wishlist, WishlistGroupedByReceiver } from 'src/domain/wishlist';
 
 export const createWishlistMock: Readonly<AddWishlistCommand> = {
   userId: 1,
@@ -36,3 +36,10 @@ export const wishlistGroupedWithDeletedMock: WishlistGroupedByReceiver[] = [
     items: [deletedWishlistItem],
   },
 ];
+export const domainWishlistMock: Wishlist = {
+  id: 1,
+  userId: 1,
+  productId: 101,
+  receiverName: '민수',
+  createdAt: new Date('2025-05-14T12:00:00Z'),
+};

--- a/src/__mock__/wishlist.mock.ts
+++ b/src/__mock__/wishlist.mock.ts
@@ -1,5 +1,5 @@
 import { AddWishlistCommand } from 'src/application/port/in/wishlist/WishlistUseCase';
-import { Wishlist, WishlistItem, WishlistSummary } from 'src/domain/wishlist';
+import { Wishlist, WishlistGroups, WishlistItem } from 'src/domain/wishlist';
 
 export const createWishlistMock: Readonly<AddWishlistCommand> = {
   userId: 1,
@@ -7,13 +7,13 @@ export const createWishlistMock: Readonly<AddWishlistCommand> = {
   receiverName: '민수',
 };
 
-export const wishlistGroupedMock: WishlistSummary[] = [
-  {
-    receiverName: '민수',
-    count: 1,
-    imageUrls: ['https://example.com/image.jpg'],
-  },
-];
+export const domainWishlistMock: Wishlist = {
+  id: 1,
+  userId: 1,
+  productId: 101,
+  receiverName: '민수',
+  createdAt: new Date('2025-05-21T10:00:00Z'),
+};
 
 export const validWishlistProduct = {
   id: 101,
@@ -22,11 +22,19 @@ export const validWishlistProduct = {
   price: 10000,
 };
 
-export const wishlistDetailMock = [
+export const wishlistGroupedMock: WishlistGroups[] = [
+  {
+    receiverName: '민수',
+    count: 1,
+    imageUrls: ['https://example.com/image.jpg'],
+  },
+];
+
+export const wishlistDetailMock: WishlistItem[] = [
   {
     wishlistId: 1,
     product: {
-      productId: 101,
+      id: 101,
       name: '감성 무드등',
       price: 10000,
       imageUrl: 'https://example.com/image.jpg',
@@ -39,7 +47,7 @@ export const wishlistDetailWithDeletedMock: WishlistItem[] = [
   {
     wishlistId: 2,
     product: {
-      productId: 999,
+      id: 999,
       name: null,
       price: null,
       imageUrl: null,
@@ -48,11 +56,3 @@ export const wishlistDetailWithDeletedMock: WishlistItem[] = [
     createdAt: new Date('2025-05-21T10:00:00Z'),
   },
 ];
-
-export const domainWishlistMock: Wishlist = {
-  id: 1,
-  userId: 1,
-  productId: 101,
-  receiverName: '민수',
-  createdAt: new Date('2025-05-21T10:00:00Z'),
-};

--- a/src/__mock__/wishlist.mock.ts
+++ b/src/__mock__/wishlist.mock.ts
@@ -1,5 +1,5 @@
 import { AddWishlistCommand } from 'src/application/port/in/wishlist/WishlistUseCase';
-import { Wishlist, WishlistGroupedByReceiver } from 'src/domain/wishlist';
+import { Wishlist, WishlistGroupedByReceiver, WishlistSummary } from 'src/domain/wishlist';
 
 export const createWishlistMock: Readonly<AddWishlistCommand> = {
   userId: 1,
@@ -24,10 +24,11 @@ export const deletedWishlistItem = {
   deleted: true,
   createdAt: new Date('2025-05-14T12:05:00Z'),
 };
-export const wishlistGroupedMock: WishlistGroupedByReceiver[] = [
+export const wishlistGroupedMock: WishlistSummary[] = [
   {
     receiverName: '민수',
-    items: [validWishlistItem],
+    count: 1,
+    imageUrls: ['https://example.com/image.jpg'],
   },
 ];
 export const wishlistGroupedWithDeletedMock: WishlistGroupedByReceiver[] = [

--- a/src/adapter/db/product.entity.ts
+++ b/src/adapter/db/product.entity.ts
@@ -49,4 +49,7 @@ export class ProductDbEntity {
 
   @Property({ onCreate: () => new Date() })
   createdAt: Date;
+
+  @Property()
+  deletedAt?: Date | null;
 }

--- a/src/adapter/db/product.gateway.ts
+++ b/src/adapter/db/product.gateway.ts
@@ -3,10 +3,10 @@ import { InjectRepository } from '@mikro-orm/nestjs';
 import { Injectable } from '@nestjs/common';
 
 import { ProductDbEntity } from './product.entity';
-import { mapToProduct } from './product.mapper';
+import { mapToProduct, mapToWishlistProduct } from './product.mapper';
 import { ProductNotFoundException } from '../../application/common/error/exception/product.exception';
 import { ProductDbQueryPort } from '../../application/port/in/product/ProductDbQueryPort';
-import { Product } from '../../domain/product';
+import { Product, WishlistProduct } from '../../domain/product';
 
 @Injectable()
 export class ProductGateway implements ProductDbQueryPort {
@@ -22,5 +22,14 @@ export class ProductGateway implements ProductDbQueryPort {
     }
 
     return mapToProduct(product);
+  }
+
+  async getWishlistProductsByIds(ids: number[]): Promise<WishlistProduct[]> {
+    const entities = await this.productRepository.find({
+      id: { $in: ids },
+      deletedAt: null,
+    });
+
+    return entities.map(mapToWishlistProduct);
   }
 }

--- a/src/adapter/db/product.mapper.ts
+++ b/src/adapter/db/product.mapper.ts
@@ -26,5 +26,6 @@ export const mapToWishlistProduct = (dbEntity: ProductDbEntity): WishlistProduct
     id: dbEntity.id,
     name: dbEntity.name,
     imageUrl: dbEntity.imageUrl,
+    price: dbEntity.price,
   };
 };

--- a/src/adapter/db/product.mapper.ts
+++ b/src/adapter/db/product.mapper.ts
@@ -1,5 +1,5 @@
 import { ProductDbEntity } from './product.entity';
-import { Product } from '../../domain/product';
+import { Product, WishlistProduct } from '../../domain/product';
 
 export const mapToProduct = (dbEntity: ProductDbEntity): Product => {
   return {
@@ -18,5 +18,13 @@ export const mapToProduct = (dbEntity: ProductDbEntity): Product => {
     targetGender: dbEntity.targetGender,
     tags: dbEntity.tags,
     nextPickProductIds: dbEntity.nextPickProductIds,
+  };
+};
+
+export const mapToWishlistProduct = (dbEntity: ProductDbEntity): WishlistProduct => {
+  return {
+    id: dbEntity.id,
+    name: dbEntity.name,
+    imageUrl: dbEntity.imageUrl,
   };
 };

--- a/src/adapter/db/wishlist.entity.ts
+++ b/src/adapter/db/wishlist.entity.ts
@@ -11,6 +11,9 @@ export class WishlistDbEntity {
   @Property()
   productId!: number;
 
+  @Property()
+  receiverName: string;
+
   @Property({ onCreate: () => new Date() })
   createdAt: Date;
 }

--- a/src/adapter/db/wishlist.entity.ts
+++ b/src/adapter/db/wishlist.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'wishlist' })
+export class WishlistDbEntity {
+  @PrimaryKey()
+  id: number;
+
+  @Property()
+  userId: number;
+
+  @Property()
+  productId!: number;
+
+  @Property({ onCreate: () => new Date() })
+  createdAt: Date;
+}

--- a/src/adapter/db/wishlist.gateway.ts
+++ b/src/adapter/db/wishlist.gateway.ts
@@ -59,7 +59,10 @@ export class WishlistGateway implements WishlistDbCommandPort, WishlistDbQueryPo
 
   async removeWishlist(wishlistId: number): Promise<void> {
     const wishlist = await this.wishlistRepository.findOne({ id: wishlistId });
+    if (!wishlist) {
+      throw new WishlistNotFoundException();
+    }
 
-    await this.em.removeAndFlush(wishlist!);
+    await this.em.removeAndFlush(wishlist);
   }
 }

--- a/src/adapter/db/wishlist.gateway.ts
+++ b/src/adapter/db/wishlist.gateway.ts
@@ -26,7 +26,7 @@ export class WishlistGateway implements WishlistDbCommandPort, WishlistDbQueryPo
     private readonly em: EntityManager,
   ) {}
 
-  async addToWishlist(command: AddWishlistCommand): Promise<void> {
+  async addWishlist(command: AddWishlistCommand): Promise<void> {
     const entity = this.wishlistRepository.create({
       userId: command.userId,
       productId: command.productId,

--- a/src/adapter/db/wishlist.gateway.ts
+++ b/src/adapter/db/wishlist.gateway.ts
@@ -2,11 +2,12 @@ import { EntityManager } from '@mikro-orm/core';
 import { EntityRepository } from '@mikro-orm/mysql';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { Injectable } from '@nestjs/common';
-import { CreateWishlistCommand } from 'src/application/port/in/wishlist/WishlistUseCase';
+import { AddWishlistCommand } from 'src/application/port/in/wishlist/WishlistUseCase';
 import { WishlistDbCommandPort } from 'src/application/port/out/WishlistDbCommandPort';
 import { WishlistDbQueryPort } from 'src/application/port/out/WishlistDbQueryPort';
-import { Wishlist } from 'src/domain/wishlist';
+import { WishlistGroupedByReceiver, WishlistItem } from 'src/domain/wishlist';
 
+import { ProductDbEntity } from './product.entity';
 import { WishlistDbEntity } from './wishlist.entity';
 import { mapToWishlist } from './wishlist.mapper';
 
@@ -15,27 +16,62 @@ export class WishlistGateway implements WishlistDbCommandPort, WishlistDbQueryPo
   constructor(
     @InjectRepository(WishlistDbEntity)
     private readonly wishlistRepository: EntityRepository<WishlistDbEntity>,
+    private readonly productRepository: EntityRepository<ProductDbEntity>,
     private readonly em: EntityManager,
   ) {}
 
-  async createWishlist(command: CreateWishlistCommand): Promise<void> {
+  async addToWishlist(command: AddWishlistCommand): Promise<void> {
     const entity = this.wishlistRepository.create({
       userId: command.userId,
       productId: command.productId,
+      receiverName: command.receiverName,
       createdAt: new Date(),
     });
     await this.em.persistAndFlush(entity);
   }
 
-  async remove(wishlistId: number): Promise<void> {
+  async removeWishlist(wishlistId: number): Promise<void> {
     await this.wishlistRepository.nativeDelete({ id: wishlistId });
   }
 
-  async getWishlistByUserId(userId: number): Promise<Wishlist[]> {
+  async getGroupedByReceiver(userId: number): Promise<WishlistGroupedByReceiver[]> {
     const entities: WishlistDbEntity[] = await this.wishlistRepository.find(
       { userId },
       { orderBy: { createdAt: 'desc' } },
     );
-    return entities.map(mapToWishlist);
+    const wishlists = entities.map(mapToWishlist);
+
+    const productIds = wishlists.map(w => w.productId);
+
+    const products = await this.productRepository.find({
+      id: { $in: productIds },
+      deletedAt: null,
+    });
+
+    const productMap = new Map<number, ProductDbEntity>(products.map(p => [p.id, p]));
+
+    const grouped = new Map<string, WishlistItem[]>();
+
+    for (const item of wishlists) {
+      const product = productMap.get(item.productId);
+
+      const dto: WishlistItem = {
+        wishlistId: item.id,
+        productId: item.productId,
+        name: product ? product.name : null,
+        imageUrl: product ? product.imageUrl : null,
+        deleted: !product,
+        createdAt: item.createdAt,
+      };
+
+      if (!grouped.has(item.receiverName)) {
+        grouped.set(item.receiverName, []);
+      }
+      grouped.get(item.receiverName)!.push(dto);
+    }
+    return Array.from(grouped.entries()).map(([receiverName, items]) => ({
+      receiverName,
+      items,
+    }));
   }
 }

--- a/src/adapter/db/wishlist.gateway.ts
+++ b/src/adapter/db/wishlist.gateway.ts
@@ -1,0 +1,41 @@
+import { EntityManager } from '@mikro-orm/core';
+import { EntityRepository } from '@mikro-orm/mysql';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { Injectable } from '@nestjs/common';
+import { CreateWishlistCommand } from 'src/application/port/in/wishlist/WishlistUseCase';
+import { WishlistDbCommandPort } from 'src/application/port/out/WishlistDbCommandPort';
+import { WishlistDbQueryPort } from 'src/application/port/out/WishlistDbQueryPort';
+import { Wishlist } from 'src/domain/wishlist';
+
+import { WishlistDbEntity } from './wishlist.entity';
+import { mapToWishlist } from './wishlist.mapper';
+
+@Injectable()
+export class WishlistGateway implements WishlistDbCommandPort, WishlistDbQueryPort {
+  constructor(
+    @InjectRepository(WishlistDbEntity)
+    private readonly wishlistRepository: EntityRepository<WishlistDbEntity>,
+    private readonly em: EntityManager,
+  ) {}
+
+  async createWishlist(command: CreateWishlistCommand): Promise<void> {
+    const entity = this.wishlistRepository.create({
+      userId: command.userId,
+      productId: command.productId,
+      createdAt: new Date(),
+    });
+    await this.em.persistAndFlush(entity);
+  }
+
+  async remove(wishlistId: number): Promise<void> {
+    await this.wishlistRepository.nativeDelete({ id: wishlistId });
+  }
+
+  async getWishlistByUserId(userId: number): Promise<Wishlist[]> {
+    const entities: WishlistDbEntity[] = await this.wishlistRepository.find(
+      { userId },
+      { orderBy: { createdAt: 'desc' } },
+    );
+    return entities.map(mapToWishlist);
+  }
+}

--- a/src/adapter/db/wishlist.gateway.ts
+++ b/src/adapter/db/wishlist.gateway.ts
@@ -1,7 +1,7 @@
 import { EntityManager } from '@mikro-orm/core';
 import { EntityRepository } from '@mikro-orm/mysql';
 import { InjectRepository } from '@mikro-orm/nestjs';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { AddWishlistCommand } from 'src/application/port/in/wishlist/WishlistUseCase';
 import { WishlistDbCommandPort } from 'src/application/port/out/WishlistDbCommandPort';
 import { WishlistDbQueryPort } from 'src/application/port/out/WishlistDbQueryPort';
@@ -16,7 +16,9 @@ export class WishlistGateway implements WishlistDbCommandPort, WishlistDbQueryPo
   constructor(
     @InjectRepository(WishlistDbEntity)
     private readonly wishlistRepository: EntityRepository<WishlistDbEntity>,
+    @InjectRepository(ProductDbEntity)
     private readonly productRepository: EntityRepository<ProductDbEntity>,
+    @Inject(EntityManager)
     private readonly em: EntityManager,
   ) {}
 

--- a/src/adapter/db/wishlist.gateway.ts
+++ b/src/adapter/db/wishlist.gateway.ts
@@ -38,6 +38,15 @@ export class WishlistGateway implements WishlistDbCommandPort, WishlistDbQueryPo
     return entities.map(mapToWishlist);
   }
 
+  async getByUserIdAndReceiverName(userId: number, receiverName: string): Promise<Wishlist[]> {
+    const entities = await this.wishlistRepository.find(
+      { userId, receiverName },
+      { orderBy: { createdAt: 'desc' } },
+    );
+
+    return entities.map(mapToWishlist);
+  }
+
   async addWishlist(command: AddWishlistCommand): Promise<void> {
     const entity = this.wishlistRepository.create({
       userId: command.userId,

--- a/src/adapter/db/wishlist.mapper.ts
+++ b/src/adapter/db/wishlist.mapper.ts
@@ -1,0 +1,12 @@
+import { Wishlist } from 'src/domain/wishlist';
+
+import { WishlistDbEntity } from './wishlist.entity';
+
+export const mapToWishlist = (dbEntity: WishlistDbEntity): Wishlist => {
+  return {
+    id: dbEntity.id,
+    userId: dbEntity.userId,
+    productId: dbEntity.productId,
+    createdAt: dbEntity.createdAt,
+  };
+};

--- a/src/adapter/db/wishlist.mapper.ts
+++ b/src/adapter/db/wishlist.mapper.ts
@@ -7,6 +7,7 @@ export const mapToWishlist = (dbEntity: WishlistDbEntity): Wishlist => {
     id: dbEntity.id,
     userId: dbEntity.userId,
     productId: dbEntity.productId,
+    receiverName: dbEntity.receiverName,
     createdAt: dbEntity.createdAt,
   };
 };

--- a/src/adapter/web/wishlist.controller.ts
+++ b/src/adapter/web/wishlist.controller.ts
@@ -1,0 +1,30 @@
+import { Body, Controller, Delete, Get, Param, Post, Req } from '@nestjs/common';
+import {
+  CreateWishlistCommand,
+  WishlistUseCase,
+} from 'src/application/port/in/wishlist/WishlistUseCase';
+import { Wishlist } from 'src/domain/wishlist';
+
+@Controller('wishlist')
+export class WishlistController {
+  constructor(private readonly wishlistUseCase: WishlistUseCase) {}
+
+  @Post()
+  async addToWishlist(@Body() body: { productId: number }, @Req() req: any): Promise<void> {
+    const command: CreateWishlistCommand = {
+      userId: req.user.id,
+      productId: body.productId,
+    };
+    await this.wishlistUseCase.addToWishlist(command);
+  }
+
+  @Delete(':id')
+  async removeFromWishlist(@Param('id') id: string): Promise<void> {
+    await this.wishlistUseCase.removeFromWishlist(Number(id));
+  }
+
+  @Get()
+  async getWishlist(@Req() req: any): Promise<Wishlist[]> {
+    return await this.wishlistUseCase.getWishlist(req.user.id);
+  }
+}

--- a/src/adapter/web/wishlist.controller.ts
+++ b/src/adapter/web/wishlist.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Inject, Param, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Inject, Param, Post, UseGuards } from '@nestjs/common';
 import {
   AddToWishlistRequest,
   AddWishlistCommand,
@@ -7,7 +7,9 @@ import {
 import { GetUser } from 'src/common/decorators/get-user.decorator';
 import { User } from 'src/domain/user';
 import { WishlistGroupedByReceiver } from 'src/domain/wishlist';
+import { JwtAuthGuard } from 'src/framework/auth/guard';
 
+@UseGuards(JwtAuthGuard)
 @Controller()
 export class WishlistController {
   constructor(
@@ -26,8 +28,8 @@ export class WishlistController {
   }
 
   @Delete(':id')
-  async removeFromWishlist(@Param('id') id: number): Promise<void> {
-    await this.wishlistUseCase.removeFromWishlist(Number(id));
+  async removeFromWishlist(@Param('id') id: number, @GetUser() user: User): Promise<void> {
+    await this.wishlistUseCase.removeFromWishlist(Number(id), user.id);
   }
 
   @Get()

--- a/src/adapter/web/wishlist.controller.ts
+++ b/src/adapter/web/wishlist.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Inject, Param, Post } from '@nestjs/common';
 import {
   AddToWishlistRequest,
   AddWishlistCommand,
@@ -8,9 +8,12 @@ import { GetUser } from 'src/common/decorators/get-user.decorator';
 import { User } from 'src/domain/user';
 import { WishlistGroupedByReceiver } from 'src/domain/wishlist';
 
-@Controller('wishlist')
+@Controller()
 export class WishlistController {
-  constructor(private readonly wishlistUseCase: WishlistUseCase) {}
+  constructor(
+    @Inject('WishlistUseCase')
+    private readonly wishlistUseCase: WishlistUseCase,
+  ) {}
 
   @Post()
   async addToWishlist(@Body() body: AddToWishlistRequest, @GetUser() user: User): Promise<void> {

--- a/src/adapter/web/wishlist.controller.ts
+++ b/src/adapter/web/wishlist.controller.ts
@@ -6,7 +6,7 @@ import {
 } from 'src/application/port/in/wishlist/WishlistUseCase';
 import { GetUser } from 'src/common/decorators/get-user.decorator';
 import { User } from 'src/domain/user';
-import { WishlistGroupedByReceiver } from 'src/domain/wishlist';
+import { WishlistSummary } from 'src/domain/wishlist';
 import { JwtAuthGuard } from 'src/framework/auth/guard';
 
 @UseGuards(JwtAuthGuard)
@@ -32,9 +32,9 @@ export class WishlistController {
     await this.wishlistUseCase.removeFromWishlist(Number(id), user.id);
   }
 
-  @Get()
-  async getWishlist(@GetUser() user: User): Promise<WishlistGroupedByReceiver[]> {
+  @Get('summary')
+  async getWishlistSummary(@GetUser() user: User): Promise<WishlistSummary[]> {
     const userId = user.id;
-    return this.wishlistUseCase.getGroupedByReceiver(userId);
+    return this.wishlistUseCase.getWishlistSummary(userId);
   }
 }

--- a/src/adapter/web/wishlist.controller.ts
+++ b/src/adapter/web/wishlist.controller.ts
@@ -1,30 +1,35 @@
-import { Body, Controller, Delete, Get, Param, Post, Req } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
 import {
-  CreateWishlistCommand,
+  AddToWishlistRequest,
+  AddWishlistCommand,
   WishlistUseCase,
 } from 'src/application/port/in/wishlist/WishlistUseCase';
-import { Wishlist } from 'src/domain/wishlist';
+import { GetUser } from 'src/common/decorators/get-user.decorator';
+import { User } from 'src/domain/user';
+import { WishlistGroupedByReceiver } from 'src/domain/wishlist';
 
 @Controller('wishlist')
 export class WishlistController {
   constructor(private readonly wishlistUseCase: WishlistUseCase) {}
 
   @Post()
-  async addToWishlist(@Body() body: { productId: number }, @Req() req: any): Promise<void> {
-    const command: CreateWishlistCommand = {
-      userId: req.user.id,
+  async addToWishlist(@Body() body: AddToWishlistRequest, @GetUser() user: User): Promise<void> {
+    const command: AddWishlistCommand = {
+      userId: user.id,
       productId: body.productId,
+      receiverName: body.receiverName,
     };
     await this.wishlistUseCase.addToWishlist(command);
   }
 
   @Delete(':id')
-  async removeFromWishlist(@Param('id') id: string): Promise<void> {
+  async removeFromWishlist(@Param('id') id: number): Promise<void> {
     await this.wishlistUseCase.removeFromWishlist(Number(id));
   }
 
   @Get()
-  async getWishlist(@Req() req: any): Promise<Wishlist[]> {
-    return await this.wishlistUseCase.getWishlist(req.user.id);
+  async getWishlist(@GetUser() user: User): Promise<WishlistGroupedByReceiver[]> {
+    const userId = user.id;
+    return this.wishlistUseCase.getGroupedByReceiver(userId);
   }
 }

--- a/src/adapter/web/wishlist.controller.ts
+++ b/src/adapter/web/wishlist.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Delete, Get, Inject, Param, Post, UseGuards } from '@nestjs/common';
 import {
-  AddToWishlistRequest,
   AddWishlistCommand,
+  AddWishlistRequest,
   WishlistUseCase,
 } from 'src/application/port/in/wishlist/WishlistUseCase';
 import { GetUser } from 'src/common/decorators/get-user.decorator';
@@ -18,7 +18,7 @@ export class WishlistController {
   ) {}
 
   @Post()
-  async addToWishlist(@Body() body: AddToWishlistRequest, @GetUser() user: User): Promise<void> {
+  async addToWishlist(@Body() body: AddWishlistRequest, @GetUser() user: User): Promise<void> {
     const command: AddWishlistCommand = {
       userId: user.id,
       productId: body.productId,

--- a/src/adapter/web/wishlist.controller.ts
+++ b/src/adapter/web/wishlist.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Delete, Get, Inject, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Inject,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import {
   AddWishlistCommand,
   AddWishlistRequest,
@@ -6,7 +16,7 @@ import {
 } from 'src/application/port/in/wishlist/WishlistUseCase';
 import { GetUser } from 'src/common/decorators/get-user.decorator';
 import { User } from 'src/domain/user';
-import { WishlistSummary } from 'src/domain/wishlist';
+import { WishlistItem, WishlistSummary } from 'src/domain/wishlist';
 import { JwtAuthGuard } from 'src/framework/auth/guard';
 
 @UseGuards(JwtAuthGuard)
@@ -36,5 +46,13 @@ export class WishlistController {
   async getWishlistSummary(@GetUser() user: User): Promise<WishlistSummary[]> {
     const userId = user.id;
     return this.wishlistUseCase.getWishlistSummary(userId);
+  }
+
+  @Get()
+  async getWishlistByReceiver(
+    @GetUser() user: User,
+    @Query('receiverName') receiverName: string,
+  ): Promise<WishlistItem[]> {
+    return this.wishlistUseCase.getWishlistByReceiver(user.id, receiverName);
   }
 }

--- a/src/adapter/web/wishlist.controller.ts
+++ b/src/adapter/web/wishlist.controller.ts
@@ -16,7 +16,7 @@ import {
 } from 'src/application/port/in/wishlist/WishlistUseCase';
 import { GetUser } from 'src/common/decorators/get-user.decorator';
 import { User } from 'src/domain/user';
-import { WishlistItem, WishlistSummary } from 'src/domain/wishlist';
+import { WishlistGroups, WishlistItem } from 'src/domain/wishlist';
 import { JwtAuthGuard } from 'src/framework/auth/guard';
 
 @UseGuards(JwtAuthGuard)
@@ -28,31 +28,31 @@ export class WishlistController {
   ) {}
 
   @Post()
-  async addToWishlist(@Body() body: AddWishlistRequest, @GetUser() user: User): Promise<void> {
+  async addWishlist(@Body() body: AddWishlistRequest, @GetUser() user: User): Promise<void> {
     const command: AddWishlistCommand = {
       userId: user.id,
       productId: body.productId,
       receiverName: body.receiverName,
     };
-    await this.wishlistUseCase.addToWishlist(command);
+    await this.wishlistUseCase.addWishlist(command);
   }
 
   @Delete(':id')
-  async removeFromWishlist(@Param('id') id: number, @GetUser() user: User): Promise<void> {
-    await this.wishlistUseCase.removeFromWishlist(Number(id), user.id);
+  async removeWishlist(@Param('id') id: number, @GetUser() user: User): Promise<void> {
+    await this.wishlistUseCase.removeWishlist(Number(id), user.id);
   }
 
   @Get('summary')
-  async getWishlistSummary(@GetUser() user: User): Promise<WishlistSummary[]> {
+  async getWishlistGroups(@GetUser() user: User): Promise<WishlistGroups[]> {
     const userId = user.id;
-    return this.wishlistUseCase.getWishlistSummary(userId);
+    return this.wishlistUseCase.getWishlistGroups(userId);
   }
 
   @Get()
-  async getWishlistByReceiver(
+  async getWishlistsByReceiverName(
     @GetUser() user: User,
     @Query('receiverName') receiverName: string,
   ): Promise<WishlistItem[]> {
-    return this.wishlistUseCase.getWishlistByReceiver(user.id, receiverName);
+    return this.wishlistUseCase.getWishlistsByReceiverName(user.id, receiverName);
   }
 }

--- a/src/application/common/error/error-messages.ts
+++ b/src/application/common/error/error-messages.ts
@@ -17,4 +17,8 @@ export const ERROR_MESSAGES = {
     NOT_FOUND: '세션을 찾을 수 없습니다.',
     INVALID_ANSWER: '유효하지 않은 답변입니다.',
   },
+  WISHLIST: {
+    FORBIDDEN_DELETE: '본인의 위시리스트 항목만 삭제할 수 있습니다.',
+    NOT_FOUND: '위시리스트 항목을 찾을 수 없습니다.',
+  },
 } as const;

--- a/src/application/common/error/exception/wishlist.exception.ts
+++ b/src/application/common/error/exception/wishlist.exception.ts
@@ -1,0 +1,14 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+
+import { ERROR_MESSAGES } from '../error-messages';
+
+export class WishlistNotFoundException extends NotFoundException {
+  constructor() {
+    super(ERROR_MESSAGES.WISHLIST.NOT_FOUND);
+  }
+}
+export class ForbiddenWishlistAccessException extends ForbiddenException {
+  constructor() {
+    super(ERROR_MESSAGES.WISHLIST.FORBIDDEN_DELETE);
+  }
+}

--- a/src/application/port/in/product/ProductDbQueryPort.ts
+++ b/src/application/port/in/product/ProductDbQueryPort.ts
@@ -1,5 +1,6 @@
-import { Product } from '../../../../domain/product';
+import { Product, WishlistProduct } from '../../../../domain/product';
 
 export interface ProductDbQueryPort {
   getProduct(id: number): Promise<Product>;
+  getWishlistProductsByIds(ids: number[]): Promise<WishlistProduct[]>;
 }

--- a/src/application/port/in/wishlist/WishlistUseCase.ts
+++ b/src/application/port/in/wishlist/WishlistUseCase.ts
@@ -1,6 +1,6 @@
 import { IsNumber, IsString } from 'class-validator';
 import { SwaggerDto } from 'src/common/decorators/swagger-dto.decorator';
-import { WishlistGroupedByReceiver } from 'src/domain/wishlist';
+import { WishlistSummary } from 'src/domain/wishlist';
 
 @SwaggerDto()
 export class AddWishlistRequest {
@@ -16,7 +16,7 @@ export interface AddWishlistCommand extends AddWishlistRequest {
 }
 
 export interface WishlistUseCase {
-  getGroupedByReceiver(userId: number): Promise<WishlistGroupedByReceiver[]>;
+  getWishlistSummary(userId: number): Promise<WishlistSummary[]>;
   addToWishlist(command: AddWishlistCommand): Promise<void>;
   removeFromWishlist(wishlistId: number, userId: number): Promise<void>;
 }

--- a/src/application/port/in/wishlist/WishlistUseCase.ts
+++ b/src/application/port/in/wishlist/WishlistUseCase.ts
@@ -1,0 +1,12 @@
+import { Wishlist } from 'src/domain/wishlist';
+
+export interface CreateWishlistCommand {
+  userId: number;
+  productId: number;
+}
+
+export interface WishlistUseCase {
+  addToWishlist(command: CreateWishlistCommand): Promise<void>;
+  removeFromWishlist(wishlistId: number): Promise<void>;
+  getWishlist(userId: number): Promise<Wishlist[]>;
+}

--- a/src/application/port/in/wishlist/WishlistUseCase.ts
+++ b/src/application/port/in/wishlist/WishlistUseCase.ts
@@ -3,7 +3,7 @@ import { SwaggerDto } from 'src/common/decorators/swagger-dto.decorator';
 import { WishlistGroupedByReceiver } from 'src/domain/wishlist';
 
 @SwaggerDto()
-export class AddToWishlistRequest {
+export class AddWishlistRequest {
   @IsNumber()
   productId: number;
 
@@ -11,14 +11,12 @@ export class AddToWishlistRequest {
   receiverName: string;
 }
 
-export interface AddWishlistCommand {
+export interface AddWishlistCommand extends AddWishlistRequest {
   userId: number;
-  productId: number;
-  receiverName: string;
 }
 
 export interface WishlistUseCase {
+  getGroupedByReceiver(userId: number): Promise<WishlistGroupedByReceiver[]>;
   addToWishlist(command: AddWishlistCommand): Promise<void>;
   removeFromWishlist(wishlistId: number, userId: number): Promise<void>;
-  getGroupedByReceiver(userId: number): Promise<WishlistGroupedByReceiver[]>;
 }

--- a/src/application/port/in/wishlist/WishlistUseCase.ts
+++ b/src/application/port/in/wishlist/WishlistUseCase.ts
@@ -19,6 +19,6 @@ export interface AddWishlistCommand {
 
 export interface WishlistUseCase {
   addToWishlist(command: AddWishlistCommand): Promise<void>;
-  removeFromWishlist(wishlistId: number): Promise<void>;
+  removeFromWishlist(wishlistId: number, userId: number): Promise<void>;
   getGroupedByReceiver(userId: number): Promise<WishlistGroupedByReceiver[]>;
 }

--- a/src/application/port/in/wishlist/WishlistUseCase.ts
+++ b/src/application/port/in/wishlist/WishlistUseCase.ts
@@ -1,6 +1,6 @@
 import { IsNumber, IsString } from 'class-validator';
 import { SwaggerDto } from 'src/common/decorators/swagger-dto.decorator';
-import { WishlistSummary } from 'src/domain/wishlist';
+import { WishlistItem, WishlistSummary } from 'src/domain/wishlist';
 
 @SwaggerDto()
 export class AddWishlistRequest {
@@ -17,6 +17,7 @@ export interface AddWishlistCommand extends AddWishlistRequest {
 
 export interface WishlistUseCase {
   getWishlistSummary(userId: number): Promise<WishlistSummary[]>;
+  getWishlistByReceiver(userid: number, receiverName: string): Promise<WishlistItem[]>;
   addToWishlist(command: AddWishlistCommand): Promise<void>;
   removeFromWishlist(wishlistId: number, userId: number): Promise<void>;
 }

--- a/src/application/port/in/wishlist/WishlistUseCase.ts
+++ b/src/application/port/in/wishlist/WishlistUseCase.ts
@@ -1,6 +1,6 @@
 import { IsNumber, IsString } from 'class-validator';
 import { SwaggerDto } from 'src/common/decorators/swagger-dto.decorator';
-import { WishlistItem, WishlistSummary } from 'src/domain/wishlist';
+import { WishlistGroups, WishlistItem } from 'src/domain/wishlist';
 
 @SwaggerDto()
 export class AddWishlistRequest {
@@ -16,8 +16,8 @@ export interface AddWishlistCommand extends AddWishlistRequest {
 }
 
 export interface WishlistUseCase {
-  getWishlistSummary(userId: number): Promise<WishlistSummary[]>;
-  getWishlistByReceiver(userid: number, receiverName: string): Promise<WishlistItem[]>;
-  addToWishlist(command: AddWishlistCommand): Promise<void>;
-  removeFromWishlist(wishlistId: number, userId: number): Promise<void>;
+  getWishlistGroups(userId: number): Promise<WishlistGroups[]>;
+  getWishlistsByReceiverName(userid: number, receiverName: string): Promise<WishlistItem[]>;
+  addWishlist(command: AddWishlistCommand): Promise<void>;
+  removeWishlist(wishlistId: number, userId: number): Promise<void>;
 }

--- a/src/application/port/in/wishlist/WishlistUseCase.ts
+++ b/src/application/port/in/wishlist/WishlistUseCase.ts
@@ -1,12 +1,24 @@
-import { Wishlist } from 'src/domain/wishlist';
+import { IsNumber, IsString } from 'class-validator';
+import { SwaggerDto } from 'src/common/decorators/swagger-dto.decorator';
+import { WishlistGroupedByReceiver } from 'src/domain/wishlist';
 
-export interface CreateWishlistCommand {
+@SwaggerDto()
+export class AddToWishlistRequest {
+  @IsNumber()
+  productId: number;
+
+  @IsString()
+  receiverName: string;
+}
+
+export interface AddWishlistCommand {
   userId: number;
   productId: number;
+  receiverName: string;
 }
 
 export interface WishlistUseCase {
-  addToWishlist(command: CreateWishlistCommand): Promise<void>;
+  addToWishlist(command: AddWishlistCommand): Promise<void>;
   removeFromWishlist(wishlistId: number): Promise<void>;
-  getWishlist(userId: number): Promise<Wishlist[]>;
+  getGroupedByReceiver(userId: number): Promise<WishlistGroupedByReceiver[]>;
 }

--- a/src/application/port/out/WishlistDbCommandPort.ts
+++ b/src/application/port/out/WishlistDbCommandPort.ts
@@ -1,0 +1,6 @@
+import { CreateWishlistCommand } from '../in/wishlist/WishlistUseCase';
+
+export interface WishlistDbCommandPort {
+  createWishlist(command: CreateWishlistCommand): Promise<void>;
+  remove(wishlistId: number): Promise<void>;
+}

--- a/src/application/port/out/WishlistDbCommandPort.ts
+++ b/src/application/port/out/WishlistDbCommandPort.ts
@@ -2,5 +2,5 @@ import { AddWishlistCommand } from '../in/wishlist/WishlistUseCase';
 
 export interface WishlistDbCommandPort {
   addToWishlist(command: AddWishlistCommand): Promise<void>;
-  removeWishlist(wishlistId: number): Promise<void>;
+  removeWishlist(wishlistId: number, userId: number): Promise<void>;
 }

--- a/src/application/port/out/WishlistDbCommandPort.ts
+++ b/src/application/port/out/WishlistDbCommandPort.ts
@@ -2,5 +2,5 @@ import { AddWishlistCommand } from '../in/wishlist/WishlistUseCase';
 
 export interface WishlistDbCommandPort {
   addWishlist(command: AddWishlistCommand): Promise<void>;
-  removeWishlist(wishlistId: number, userId: number): Promise<void>;
+  removeWishlist(id: number): Promise<void>;
 }

--- a/src/application/port/out/WishlistDbCommandPort.ts
+++ b/src/application/port/out/WishlistDbCommandPort.ts
@@ -1,6 +1,6 @@
 import { AddWishlistCommand } from '../in/wishlist/WishlistUseCase';
 
 export interface WishlistDbCommandPort {
-  addToWishlist(command: AddWishlistCommand): Promise<void>;
+  addWishlist(command: AddWishlistCommand): Promise<void>;
   removeWishlist(wishlistId: number, userId: number): Promise<void>;
 }

--- a/src/application/port/out/WishlistDbCommandPort.ts
+++ b/src/application/port/out/WishlistDbCommandPort.ts
@@ -1,6 +1,6 @@
-import { CreateWishlistCommand } from '../in/wishlist/WishlistUseCase';
+import { AddWishlistCommand } from '../in/wishlist/WishlistUseCase';
 
 export interface WishlistDbCommandPort {
-  createWishlist(command: CreateWishlistCommand): Promise<void>;
-  remove(wishlistId: number): Promise<void>;
+  addToWishlist(command: AddWishlistCommand): Promise<void>;
+  removeWishlist(wishlistId: number): Promise<void>;
 }

--- a/src/application/port/out/WishlistDbQueryPort.ts
+++ b/src/application/port/out/WishlistDbQueryPort.ts
@@ -1,5 +1,5 @@
-import { Wishlist } from 'src/domain/wishlist';
+import { WishlistGroupedByReceiver } from 'src/domain/wishlist';
 
 export interface WishlistDbQueryPort {
-  getWishlistByUserId(userId: number): Promise<Wishlist[]>;
+  getGroupedByReceiver(userId: number): Promise<WishlistGroupedByReceiver[]>;
 }

--- a/src/application/port/out/WishlistDbQueryPort.ts
+++ b/src/application/port/out/WishlistDbQueryPort.ts
@@ -1,5 +1,6 @@
-import { WishlistGroupedByReceiver } from 'src/domain/wishlist';
+import { Wishlist, WishlistGroupedByReceiver } from 'src/domain/wishlist';
 
 export interface WishlistDbQueryPort {
+  getWishlistById(wishlistId: number): Promise<Wishlist>;
   getGroupedByReceiver(userId: number): Promise<WishlistGroupedByReceiver[]>;
 }

--- a/src/application/port/out/WishlistDbQueryPort.ts
+++ b/src/application/port/out/WishlistDbQueryPort.ts
@@ -1,0 +1,5 @@
+import { Wishlist } from 'src/domain/wishlist';
+
+export interface WishlistDbQueryPort {
+  getWishlistByUserId(userId: number): Promise<Wishlist[]>;
+}

--- a/src/application/port/out/WishlistDbQueryPort.ts
+++ b/src/application/port/out/WishlistDbQueryPort.ts
@@ -3,4 +3,5 @@ import { Wishlist } from 'src/domain/wishlist';
 export interface WishlistDbQueryPort {
   getWishlistById(wishlistId: number): Promise<Wishlist>;
   getAllByUserId(userId: number): Promise<Wishlist[]>;
+  getByUserIdAndReceiverName(userId: number, receiverName: string): Promise<Wishlist[]>;
 }

--- a/src/application/port/out/WishlistDbQueryPort.ts
+++ b/src/application/port/out/WishlistDbQueryPort.ts
@@ -1,6 +1,6 @@
-import { Wishlist, WishlistGroupedByReceiver } from 'src/domain/wishlist';
+import { Wishlist } from 'src/domain/wishlist';
 
 export interface WishlistDbQueryPort {
   getWishlistById(wishlistId: number): Promise<Wishlist>;
-  getGroupedByReceiver(userId: number): Promise<WishlistGroupedByReceiver[]>;
+  getAllByUserId(userId: number): Promise<Wishlist[]>;
 }

--- a/src/application/service/Wishlist.service.spec.ts
+++ b/src/application/service/Wishlist.service.spec.ts
@@ -1,0 +1,97 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { WishlistService } from './Wishlist.service';
+import {
+  createWishlistMock,
+  wishlistGroupedMock,
+  wishlistGroupedWithDeletedMock,
+} from '../../__mock__/wishlist.mock';
+import { WishlistDbCommandPort } from '../port/out/WishlistDbCommandPort';
+import { WishlistDbQueryPort } from '../port/out/WishlistDbQueryPort';
+
+describe('WishlistService', () => {
+  let service: WishlistService;
+  let queryPortMock: jest.Mocked<WishlistDbQueryPort>;
+  let commandPortMock: jest.Mocked<WishlistDbCommandPort>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WishlistService,
+        {
+          provide: 'WishlistDbCommandPort',
+          useValue: {
+            createWishlist: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+        {
+          provide: 'WishlistDbQueryPort',
+          useValue: {
+            getGroupedByReceiver: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<WishlistService>(WishlistService);
+    queryPortMock = module.get<jest.Mocked<WishlistDbQueryPort>>('WishlistDbQueryPort');
+    commandPortMock = module.get<jest.Mocked<WishlistDbCommandPort>>('WishlistDbCommandPort');
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('addToWishlist', () => {
+    it('위시리스트에 상품을 추가할 수 있다', async () => {
+      //given
+      const command = createWishlistMock;
+
+      //when
+      await service.addToWishlist(command);
+
+      //then
+      expect(commandPortMock.addToWishlist).toHaveBeenCalledWith(command);
+    });
+  });
+
+  describe('removeFromWishlist', () => {
+    it('위시리스트에서 상품을 삭제할 수 있다', async () => {
+      //given
+      const wishlistId = 1;
+
+      //when
+      await service.removeFromWishlist(wishlistId);
+
+      //then
+      expect(commandPortMock.removeWishlist).toHaveBeenCalledWith(wishlistId);
+    });
+  });
+  describe('getGroupedByReceiver', () => {
+    it('사용자의 위시리스트 받는 사람을 기준으로 그룹화해 조회할 수 있다', async () => {
+      //given
+      const userId = 1;
+      queryPortMock.getGroupedByReceiver.mockResolvedValueOnce(wishlistGroupedMock);
+
+      //when
+      const result = await service.getGroupedByReceiver(userId);
+
+      //then
+      expect(result).toEqual(wishlistGroupedMock);
+      expect(queryPortMock.getGroupedByReceiver).toHaveBeenCalledWith(userId);
+    });
+    it('삭제된 상품의 경우 deleted: true로 응답해야 한다', async () => {
+      //given
+      const userId = 1;
+      queryPortMock.getGroupedByReceiver.mockRejectedValueOnce(wishlistGroupedWithDeletedMock);
+
+      //when
+      const result = await service.getGroupedByReceiver(userId);
+
+      //then
+      expect(result).toEqual(wishlistGroupedWithDeletedMock);
+      expect(queryPortMock.getGroupedByReceiver).toHaveBeenCalledWith(userId);
+    });
+  });
+});

--- a/src/application/service/Wishlist.service.spec.ts
+++ b/src/application/service/Wishlist.service.spec.ts
@@ -51,7 +51,7 @@ describe('WishlistService', () => {
       await service.addToWishlist(command);
 
       //then
-      expect(commandPortMock.addToWishlist).toHaveBeenCalledWith(command);
+      expect(commandPortMock.addWishlist).toHaveBeenCalledWith(command);
     });
   });
 

--- a/src/application/service/Wishlist.service.spec.ts
+++ b/src/application/service/Wishlist.service.spec.ts
@@ -19,15 +19,10 @@ describe('WishlistService', () => {
       providers: [
         WishlistService,
         {
-          provide: 'WishlistDbCommandPort',
+          provide: 'WishlistGateway',
           useValue: {
-            createWishlist: jest.fn(),
-            remove: jest.fn(),
-          },
-        },
-        {
-          provide: 'WishlistDbQueryPort',
-          useValue: {
+            addToWishlist: jest.fn(),
+            removeWishlist: jest.fn(),
             getGroupedByReceiver: jest.fn(),
           },
         },
@@ -35,8 +30,8 @@ describe('WishlistService', () => {
     }).compile();
 
     service = module.get<WishlistService>(WishlistService);
-    queryPortMock = module.get<jest.Mocked<WishlistDbQueryPort>>('WishlistDbQueryPort');
-    commandPortMock = module.get<jest.Mocked<WishlistDbCommandPort>>('WishlistDbCommandPort');
+    queryPortMock = module.get<jest.Mocked<WishlistDbQueryPort>>('WishlistGateway');
+    commandPortMock = module.get<jest.Mocked<WishlistDbCommandPort>>('WishlistGateway');
   });
 
   it('should be defined', () => {
@@ -84,7 +79,7 @@ describe('WishlistService', () => {
     it('삭제된 상품의 경우 deleted: true로 응답해야 한다', async () => {
       //given
       const userId = 1;
-      queryPortMock.getGroupedByReceiver.mockRejectedValueOnce(wishlistGroupedWithDeletedMock);
+      queryPortMock.getGroupedByReceiver.mockResolvedValueOnce(wishlistGroupedWithDeletedMock);
 
       //when
       const result = await service.getGroupedByReceiver(userId);

--- a/src/application/service/Wishlist.service.spec.ts
+++ b/src/application/service/Wishlist.service.spec.ts
@@ -56,26 +56,26 @@ describe('WishlistService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('addToWishlist', () => {
+  describe('addWishlist', () => {
     it('위시리스트에 상품을 추가할 수 있다', async () => {
       //given
       const command = createWishlistMock;
 
       //when
-      await service.addToWishlist(command);
+      await service.addWishlist(command);
 
       //then
       expect(commandPortMock.addWishlist).toHaveBeenCalledWith(command);
     });
   });
 
-  describe('removeFromWishlist', () => {
+  describe('removeWishlist', () => {
     it('자신의 위시리스트에서 상품을 삭제할 수 있다', async () => {
       //given
       queryPortMock.getWishlistById.mockResolvedValue(domainWishlistMock);
 
       //when
-      await service.removeFromWishlist(domainWishlistMock.id, domainWishlistMock.userId);
+      await service.removeWishlist(domainWishlistMock.id, domainWishlistMock.userId);
 
       //then
       expect(commandPortMock.removeWishlist).toHaveBeenCalledWith(domainWishlistMock.id);
@@ -89,7 +89,7 @@ describe('WishlistService', () => {
       });
 
       // then
-      await expect(service.removeFromWishlist(wishlistId, userId)).rejects.toThrow(
+      await expect(service.removeWishlist(wishlistId, userId)).rejects.toThrow(
         WishlistNotFoundException,
       );
     });
@@ -98,20 +98,20 @@ describe('WishlistService', () => {
       queryPortMock.getWishlistById.mockResolvedValue({ ...domainWishlistMock, userId: 999 });
 
       // then
-      await expect(service.removeFromWishlist(domainWishlistMock.id, 1)).rejects.toThrow(
+      await expect(service.removeWishlist(domainWishlistMock.id, 1)).rejects.toThrow(
         ForbiddenWishlistAccessException,
       );
     });
   });
-  describe('getWishlistSummary', () => {
-    it('사용자의 위시리스트 받는 사람을 기준으로 요약 조회할 수 있다', async () => {
+  describe('getWishlistGroups', () => {
+    it('사용자의 위시리스트 수신자 기준으로 그룹핑하여 반환할 수 있다', async () => {
       //given
       const userId = 1;
       queryPortMock.getAllByUserId.mockResolvedValueOnce([domainWishlistMock]);
       productPortMock.getWishlistProductsByIds.mockResolvedValueOnce([validWishlistProduct]);
 
       //when
-      const result = await service.getWishlistSummary(userId);
+      const result = await service.getWishlistGroups(userId);
 
       //then
       expect(result).toEqual(wishlistGroupedMock);
@@ -120,17 +120,15 @@ describe('WishlistService', () => {
     });
   });
   describe('getWishlistByReceiver', () => {
-    it('특정 수신자의 위시리스트 상세 목록을 반환할 수 있다', async () => {
+    it('receiverName으로 위시리스트 상세 목록을 반환한다', async () => {
       // given
       const userId = 1;
       const receiverName = '민수';
-
       queryPortMock.getByUserIdAndReceiverName.mockResolvedValueOnce([domainWishlistMock]);
-
       productPortMock.getWishlistProductsByIds.mockResolvedValueOnce([validWishlistProduct]);
 
       // when
-      const result = await service.getWishlistByReceiver(userId, receiverName);
+      const result = await service.getWishlistsByReceiverName(userId, receiverName);
 
       // then
       expect(result).toEqual(wishlistDetailMock);
@@ -138,11 +136,10 @@ describe('WishlistService', () => {
       expect(productPortMock.getWishlistProductsByIds).toHaveBeenCalledWith([101]);
     });
 
-    it('삭제된 상품의 경우 deleted: true로 응답해야 한다', async () => {
+    it('삭제된 상품이면 deleted: true로 반환한다', async () => {
       //given
       const userId = 1;
       const receiverName = '민수';
-
       queryPortMock.getByUserIdAndReceiverName.mockResolvedValueOnce([
         {
           id: 2,
@@ -155,7 +152,7 @@ describe('WishlistService', () => {
       productPortMock.getWishlistProductsByIds.mockResolvedValueOnce([]);
 
       //when
-      const result = await service.getWishlistByReceiver(userId, receiverName);
+      const result = await service.getWishlistsByReceiverName(userId, receiverName);
 
       //then
       expect(result).toEqual(wishlistDetailWithDeletedMock);

--- a/src/application/service/Wishlist.service.spec.ts
+++ b/src/application/service/Wishlist.service.spec.ts
@@ -101,8 +101,8 @@ describe('WishlistService', () => {
       );
     });
   });
-  describe('getGroupedByReceiver', () => {
-    it('사용자의 위시리스트 받는 사람을 기준으로 그룹화해 조회할 수 있다', async () => {
+  describe('getWishlistSummary', () => {
+    it('사용자의 위시리스트 받는 사람을 기준으로 요약 조회할 수 있다', async () => {
       //given
       const userId = 1;
       queryPortMock.getAllByUserId.mockResolvedValueOnce([domainWishlistMock]);
@@ -115,7 +115,7 @@ describe('WishlistService', () => {
       ]);
 
       //when
-      const result = await service.getGroupedByReceiver(userId);
+      const result = await service.getWishlistSummary(userId);
 
       //then
       expect(result).toEqual(wishlistGroupedMock);
@@ -137,7 +137,7 @@ describe('WishlistService', () => {
       productPortMock.getWishlistProductsByIds.mockResolvedValueOnce([]);
 
       //when
-      const result = await service.getGroupedByReceiver(userId);
+      const result = await service.getWishlistSummary(userId);
 
       //then
       expect(result).toEqual(wishlistGroupedWithDeletedMock);

--- a/src/application/service/Wishlist.service.ts
+++ b/src/application/service/Wishlist.service.ts
@@ -1,6 +1,10 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WishlistGroupedByReceiver } from 'src/domain/wishlist';
 
+import {
+  ForbiddenWishlistAccessException,
+  WishlistNotFoundException,
+} from '../common/error/exception/wishlist.exception';
 import { AddWishlistCommand, WishlistUseCase } from '../port/in/wishlist/WishlistUseCase';
 import { WishlistDbCommandPort } from '../port/out/WishlistDbCommandPort';
 import { WishlistDbQueryPort } from '../port/out/WishlistDbQueryPort';
@@ -23,6 +27,15 @@ export class WishlistService implements WishlistUseCase {
   }
 
   async removeFromWishlist(wishlistId: number, userId: number): Promise<void> {
-    await this.wishlistDbCommandPort.removeWishlist(wishlistId, userId);
+    const wishlist = await this.wishlistDbQueryPort.getWishlistById(wishlistId);
+
+    if (!wishlist) {
+      throw new WishlistNotFoundException();
+    }
+
+    if (wishlist.userId !== userId) {
+      throw new ForbiddenWishlistAccessException();
+    }
+    await this.wishlistDbCommandPort.removeWishlist(wishlistId);
   }
 }

--- a/src/application/service/Wishlist.service.ts
+++ b/src/application/service/Wishlist.service.ts
@@ -18,8 +18,8 @@ export class WishlistService implements WishlistUseCase {
     await this.wishlistDbCommandPort.addToWishlist(command);
   }
 
-  async removeFromWishlist(wishlistId: number): Promise<void> {
-    await this.wishlistDbCommandPort.removeWishlist(wishlistId);
+  async removeFromWishlist(wishlistId: number, userId: number): Promise<void> {
+    await this.wishlistDbCommandPort.removeWishlist(wishlistId, userId);
   }
 
   async getGroupedByReceiver(userId: number): Promise<WishlistGroupedByReceiver[]> {

--- a/src/application/service/Wishlist.service.ts
+++ b/src/application/service/Wishlist.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { Wishlist } from 'src/domain/wishlist';
+import { WishlistGroupedByReceiver } from 'src/domain/wishlist';
 
-import { CreateWishlistCommand, WishlistUseCase } from '../port/in/wishlist/WishlistUseCase';
+import { AddWishlistCommand, WishlistUseCase } from '../port/in/wishlist/WishlistUseCase';
 import { WishlistDbCommandPort } from '../port/out/WishlistDbCommandPort';
 import { WishlistDbQueryPort } from '../port/out/WishlistDbQueryPort';
 
@@ -14,15 +14,15 @@ export class WishlistService implements WishlistUseCase {
     private readonly wishlistDbCommandPort: WishlistDbCommandPort,
   ) {}
 
-  async addToWishlist(command: CreateWishlistCommand): Promise<void> {
-    await this.wishlistDbCommandPort.createWishlist(command);
+  async addToWishlist(command: AddWishlistCommand): Promise<void> {
+    await this.wishlistDbCommandPort.addToWishlist(command);
   }
 
   async removeFromWishlist(wishlistId: number): Promise<void> {
-    await this.wishlistDbCommandPort.remove(wishlistId);
+    await this.wishlistDbCommandPort.removeWishlist(wishlistId);
   }
 
-  async getWishlist(userId: number): Promise<Wishlist[]> {
-    return await this.wishlistDbQueryPort.getWishlistByUserId(userId);
+  async getGroupedByReceiver(userId: number): Promise<WishlistGroupedByReceiver[]> {
+    return await this.wishlistDbQueryPort.getGroupedByReceiver(userId);
   }
 }

--- a/src/application/service/Wishlist.service.ts
+++ b/src/application/service/Wishlist.service.ts
@@ -1,10 +1,11 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { WishlistGroupedByReceiver } from 'src/domain/wishlist';
+import { WishlistGroupedByReceiver, WishlistItem } from 'src/domain/wishlist';
 
 import {
   ForbiddenWishlistAccessException,
   WishlistNotFoundException,
 } from '../common/error/exception/wishlist.exception';
+import { ProductDbQueryPort } from '../port/in/product/ProductDbQueryPort';
 import { AddWishlistCommand, WishlistUseCase } from '../port/in/wishlist/WishlistUseCase';
 import { WishlistDbCommandPort } from '../port/out/WishlistDbCommandPort';
 import { WishlistDbQueryPort } from '../port/out/WishlistDbQueryPort';
@@ -16,10 +17,41 @@ export class WishlistService implements WishlistUseCase {
     private readonly wishlistDbQueryPort: WishlistDbQueryPort,
     @Inject('WishlistGateway')
     private readonly wishlistDbCommandPort: WishlistDbCommandPort,
+    @Inject('ProductGateway')
+    private readonly productDbQueryPort: ProductDbQueryPort,
   ) {}
 
   async getGroupedByReceiver(userId: number): Promise<WishlistGroupedByReceiver[]> {
-    return await this.wishlistDbQueryPort.getGroupedByReceiver(userId);
+    const wishlists = await this.wishlistDbQueryPort.getAllByUserId(userId);
+    const productIds = wishlists.map(w => w.productId);
+
+    const products = await this.productDbQueryPort.getWishlistProductsByIds(productIds);
+    const productMap = new Map(products.map(p => [p.id, p]));
+
+    const grouped = new Map<string, WishlistItem[]>();
+
+    for (const item of wishlists) {
+      const product = productMap.get(item.productId);
+
+      const dto: WishlistItem = {
+        wishlistId: item.id,
+        productId: item.productId,
+        name: product ? product.name : null,
+        imageUrl: product ? product.imageUrl : null,
+        deleted: !product,
+        createdAt: item.createdAt,
+      };
+
+      if (!grouped.has(item.receiverName)) {
+        grouped.set(item.receiverName, []);
+      }
+      grouped.get(item.receiverName)!.push(dto);
+    }
+
+    return Array.from(grouped.entries()).map(([receiverName, items]) => ({
+      receiverName,
+      items,
+    }));
   }
 
   async addToWishlist(command: AddWishlistCommand): Promise<void> {

--- a/src/application/service/Wishlist.service.ts
+++ b/src/application/service/Wishlist.service.ts
@@ -14,15 +14,15 @@ export class WishlistService implements WishlistUseCase {
     private readonly wishlistDbCommandPort: WishlistDbCommandPort,
   ) {}
 
+  async getGroupedByReceiver(userId: number): Promise<WishlistGroupedByReceiver[]> {
+    return await this.wishlistDbQueryPort.getGroupedByReceiver(userId);
+  }
+
   async addToWishlist(command: AddWishlistCommand): Promise<void> {
-    await this.wishlistDbCommandPort.addToWishlist(command);
+    await this.wishlistDbCommandPort.addWishlist(command);
   }
 
   async removeFromWishlist(wishlistId: number, userId: number): Promise<void> {
     await this.wishlistDbCommandPort.removeWishlist(wishlistId, userId);
-  }
-
-  async getGroupedByReceiver(userId: number): Promise<WishlistGroupedByReceiver[]> {
-    return await this.wishlistDbQueryPort.getGroupedByReceiver(userId);
   }
 }

--- a/src/application/service/Wishlist.service.ts
+++ b/src/application/service/Wishlist.service.ts
@@ -1,0 +1,28 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Wishlist } from 'src/domain/wishlist';
+
+import { CreateWishlistCommand, WishlistUseCase } from '../port/in/wishlist/WishlistUseCase';
+import { WishlistDbCommandPort } from '../port/out/WishlistDbCommandPort';
+import { WishlistDbQueryPort } from '../port/out/WishlistDbQueryPort';
+
+@Injectable()
+export class WishlistService implements WishlistUseCase {
+  constructor(
+    @Inject('WishlistGateway')
+    private readonly wishlistDbQueryPort: WishlistDbQueryPort,
+    @Inject('WishlistGateway')
+    private readonly wishlistDbCommandPort: WishlistDbCommandPort,
+  ) {}
+
+  async addToWishlist(command: CreateWishlistCommand): Promise<void> {
+    await this.wishlistDbCommandPort.createWishlist(command);
+  }
+
+  async removeFromWishlist(wishlistId: number): Promise<void> {
+    await this.wishlistDbCommandPort.remove(wishlistId);
+  }
+
+  async getWishlist(userId: number): Promise<Wishlist[]> {
+    return await this.wishlistDbQueryPort.getWishlistByUserId(userId);
+  }
+}

--- a/src/application/service/recommend-session.service.spec.ts
+++ b/src/application/service/recommend-session.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { RecommendSessionService } from './recommend-session.service';
 import {
   commonQuestionMockData,
   recommendSessionMockData,
@@ -19,7 +20,6 @@ import {
 import { CommonQuestionDbQueryPort } from '../port/out/CommonQuestionDbQueryPort';
 import { RecommendSessionDbCommandPort } from '../port/out/RecommendSessionDbCommandPort';
 import { RecommendSessionDbQueryPort } from '../port/out/RecommendSessionDbQueryPort';
-import { RecommendSessionService } from './recommend-session.service';
 
 describe('RecommendSessionService', () => {
   let service: RecommendSessionService;

--- a/src/domain/product.ts
+++ b/src/domain/product.ts
@@ -20,4 +20,5 @@ export class WishlistProduct {
   id: number;
   name: string;
   imageUrl: string;
+  price: number;
 }

--- a/src/domain/product.ts
+++ b/src/domain/product.ts
@@ -15,3 +15,9 @@ export class Product {
   tags: string[];
   nextPickProductIds: number[];
 }
+
+export class WishlistProduct {
+  id: number;
+  name: string;
+  imageUrl: string;
+}

--- a/src/domain/wishlist.ts
+++ b/src/domain/wishlist.ts
@@ -9,7 +9,7 @@ export class Wishlist {
 export class WishlistItem {
   wishlistId: number;
   product: {
-    productId: number;
+    id: number;
     name: string | null;
     price: number | null;
     imageUrl: string | null;
@@ -19,7 +19,7 @@ export class WishlistItem {
   createdAt: Date;
 }
 
-export class WishlistSummary {
+export class WishlistGroups {
   receiverName: string;
   count: number;
   imageUrls: string[];

--- a/src/domain/wishlist.ts
+++ b/src/domain/wishlist.ts
@@ -8,9 +8,13 @@ export class Wishlist {
 
 export class WishlistItem {
   wishlistId: number;
-  productId: number;
-  name: string | null;
-  imageUrl: string | null;
+  product: {
+    productId: number;
+    name: string | null;
+    price: number | null;
+    imageUrl: string | null;
+  };
+
   deleted: boolean;
   createdAt: Date;
 }

--- a/src/domain/wishlist.ts
+++ b/src/domain/wishlist.ts
@@ -1,0 +1,6 @@
+export class Wishlist {
+  id: number;
+  userId: number;
+  productId: number;
+  createdAt: Date;
+}

--- a/src/domain/wishlist.ts
+++ b/src/domain/wishlist.ts
@@ -2,5 +2,20 @@ export class Wishlist {
   id: number;
   userId: number;
   productId: number;
+  receiverName: string;
   createdAt: Date;
+}
+
+export class WishlistItem {
+  wishlistId: number;
+  productId: number;
+  name: string | null;
+  imageUrl: string | null;
+  deleted: boolean;
+  createdAt: Date;
+}
+
+export class WishlistGroupedByReceiver {
+  receiverName: string;
+  items: WishlistItem[];
 }

--- a/src/domain/wishlist.ts
+++ b/src/domain/wishlist.ts
@@ -15,6 +15,12 @@ export class WishlistItem {
   createdAt: Date;
 }
 
+export class WishlistSummary {
+  receiverName: string;
+  count: number;
+  imageUrls: string[];
+}
+
 export class WishlistGroupedByReceiver {
   receiverName: string;
   items: WishlistItem[];

--- a/src/framework/module/app.module.ts
+++ b/src/framework/module/app.module.ts
@@ -11,6 +11,7 @@ import { PostModule } from './post.module';
 import { ProductModule } from './product.module';
 import { RecommendSessionModule } from './recommend-session.module';
 import { UserModule } from './user.module';
+import { WishlistModule } from './wishlist.module';
 import { JwtAuthGuard } from '../auth/guard';
 import createMikroOrmConfig from '../config/mikro-orm.config';
 
@@ -25,6 +26,7 @@ import createMikroOrmConfig from '../config/mikro-orm.config';
     ProductModule,
     UserModule,
     RecommendSessionModule,
+    WishlistModule,
     MikroOrmModule.forRootAsync({
       useFactory: async () => await createMikroOrmConfig(),
     }),
@@ -41,6 +43,7 @@ import createMikroOrmConfig from '../config/mikro-orm.config';
               { path: 'product', module: ProductModule },
               { path: 'recommend-session', module: RecommendSessionModule },
               { path: 'user', module: UserModule },
+              { path: 'wishlist', module: WishlistModule },
             ],
           },
         ],

--- a/src/framework/module/product.module.ts
+++ b/src/framework/module/product.module.ts
@@ -19,6 +19,6 @@ import { ProductService } from '../../application/service/product.service';
       useClass: ProductGateway,
     },
   ],
-  exports: ['ProductUseCase'],
+  exports: ['ProductUseCase', 'ProductGateway'],
 })
 export class ProductModule {}

--- a/src/framework/module/wishlist.module.ts
+++ b/src/framework/module/wishlist.module.ts
@@ -1,16 +1,21 @@
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Module } from '@nestjs/common';
+import { ProductDbEntity } from 'src/adapter/db/product.entity';
 import { WishlistDbEntity } from 'src/adapter/db/wishlist.entity';
 import { WishlistGateway } from 'src/adapter/db/wishlist.gateway';
 import { WishlistController } from 'src/adapter/web/wishlist.controller';
 import { WishlistService } from 'src/application/service/Wishlist.service';
 
 @Module({
-  imports: [MikroOrmModule.forFeature([WishlistDbEntity])],
+  imports: [MikroOrmModule.forFeature([WishlistDbEntity, ProductDbEntity])],
   controllers: [WishlistController],
   providers: [
     WishlistService,
     WishlistGateway,
+    {
+      provide: 'WishlistUseCase',
+      useClass: WishlistService,
+    },
     {
       provide: 'WishlistGateway',
       useExisting: WishlistGateway,

--- a/src/framework/module/wishlist.module.ts
+++ b/src/framework/module/wishlist.module.ts
@@ -1,15 +1,15 @@
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Module } from '@nestjs/common';
-import { ProductDbEntity } from 'src/adapter/db/product.entity';
 import { WishlistDbEntity } from 'src/adapter/db/wishlist.entity';
 import { WishlistGateway } from 'src/adapter/db/wishlist.gateway';
 import { WishlistController } from 'src/adapter/web/wishlist.controller';
 import { WishlistService } from 'src/application/service/Wishlist.service';
 
 import { AuthGuardModule } from './auth.guard.module';
+import { ProductModule } from './product.module';
 
 @Module({
-  imports: [MikroOrmModule.forFeature([WishlistDbEntity, ProductDbEntity]), AuthGuardModule],
+  imports: [MikroOrmModule.forFeature([WishlistDbEntity]), AuthGuardModule, ProductModule],
   controllers: [WishlistController],
   providers: [
     WishlistService,

--- a/src/framework/module/wishlist.module.ts
+++ b/src/framework/module/wishlist.module.ts
@@ -6,8 +6,10 @@ import { WishlistGateway } from 'src/adapter/db/wishlist.gateway';
 import { WishlistController } from 'src/adapter/web/wishlist.controller';
 import { WishlistService } from 'src/application/service/Wishlist.service';
 
+import { AuthGuardModule } from './auth.guard.module';
+
 @Module({
-  imports: [MikroOrmModule.forFeature([WishlistDbEntity, ProductDbEntity])],
+  imports: [MikroOrmModule.forFeature([WishlistDbEntity, ProductDbEntity]), AuthGuardModule],
   controllers: [WishlistController],
   providers: [
     WishlistService,

--- a/src/framework/module/wishlist.module.ts
+++ b/src/framework/module/wishlist.module.ts
@@ -1,19 +1,21 @@
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Module } from '@nestjs/common';
+import { ProductDbEntity } from 'src/adapter/db/product.entity';
+import { ProductGateway } from 'src/adapter/db/product.gateway';
 import { WishlistDbEntity } from 'src/adapter/db/wishlist.entity';
 import { WishlistGateway } from 'src/adapter/db/wishlist.gateway';
 import { WishlistController } from 'src/adapter/web/wishlist.controller';
 import { WishlistService } from 'src/application/service/Wishlist.service';
 
 import { AuthGuardModule } from './auth.guard.module';
-import { ProductModule } from './product.module';
 
 @Module({
-  imports: [MikroOrmModule.forFeature([WishlistDbEntity]), AuthGuardModule, ProductModule],
+  imports: [MikroOrmModule.forFeature([WishlistDbEntity, ProductDbEntity]), AuthGuardModule],
   controllers: [WishlistController],
   providers: [
     WishlistService,
     WishlistGateway,
+    ProductGateway,
     {
       provide: 'WishlistUseCase',
       useClass: WishlistService,
@@ -21,6 +23,10 @@ import { ProductModule } from './product.module';
     {
       provide: 'WishlistGateway',
       useExisting: WishlistGateway,
+    },
+    {
+      provide: 'ProductGateway',
+      useExisting: ProductGateway,
     },
   ],
 })

--- a/src/framework/module/wishlist.module.ts
+++ b/src/framework/module/wishlist.module.ts
@@ -1,0 +1,20 @@
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { Module } from '@nestjs/common';
+import { WishlistDbEntity } from 'src/adapter/db/wishlist.entity';
+import { WishlistGateway } from 'src/adapter/db/wishlist.gateway';
+import { WishlistController } from 'src/adapter/web/wishlist.controller';
+import { WishlistService } from 'src/application/service/Wishlist.service';
+
+@Module({
+  imports: [MikroOrmModule.forFeature([WishlistDbEntity])],
+  controllers: [WishlistController],
+  providers: [
+    WishlistService,
+    WishlistGateway,
+    {
+      provide: 'WishlistGateway',
+      useExisting: WishlistGateway,
+    },
+  ],
+})
+export class WishlistModule {}


### PR DESCRIPTION
- `/wishlists/summary` : 수신자 기준 요약 목록 조회 API 구현
- `/wishlists?receiverName=xxx` : 수신자별 상세 위시리스트 조회 API 구현
- 삭제된 상품은 deleted: true로 응답되도록 처리
- 유닛 테스트 케이스 추가 및 목 데이터 정리