### PR TITLE
feat: 위시리스트 상세 목록 내 상품 url 추가

### DIFF
--- a/src/__mock__/wishlist.mock.ts
+++ b/src/__mock__/wishlist.mock.ts
@@ -12,6 +12,7 @@ export const domainWishlistMockData: Wishlist = {
 export const wishlistProductMockData: WishlistProduct = {
   id: 101,
   name: '감성 무드등',
+  url: 'https://smartstore.naver.com/coredak/products/4785024689',
   imageUrl: 'https://example.com/image.jpg',
   price: 10000,
 };

--- a/src/adapter/db/product.mapper.ts
+++ b/src/adapter/db/product.mapper.ts
@@ -35,6 +35,7 @@ export const mapToWishlistProduct = (dbEntity: ProductDbEntity): WishlistProduct
   return {
     id: dbEntity.id,
     name: dbEntity.name,
+    url: dbEntity.url,
     imageUrl: dbEntity.imageUrl,
     price: dbEntity.price,
   };

--- a/src/application/service/Wishlist.service.ts
+++ b/src/application/service/Wishlist.service.ts
@@ -52,6 +52,7 @@ export class WishlistService implements WishlistUseCase {
               id: item.productId,
               name: product.name,
               price: product.price,
+              url: product.url,
               imageUrl: product.imageUrl,
             }
           : null,

--- a/src/domain/product.ts
+++ b/src/domain/product.ts
@@ -27,6 +27,7 @@ export class NextPickProduct {
 export class WishlistProduct {
   id: number;
   name: string;
+  url: string;
   imageUrl: string;
   price: number;
 }

--- a/src/domain/wishlist.ts
+++ b/src/domain/wishlist.ts
@@ -12,6 +12,7 @@ export class WishlistItem {
     id: number;
     name: string;
     price: number;
+    url: string;
     imageUrl: string;
   } | null;
 


### PR DESCRIPTION
receiverName기준으로 위시리스트 상세 내역 반환 내 상품 url 추가했습니다.
위시리스트 상세페이지에서 구매하기 클릭 시 바로 구매 링크로 넘어가기 위함입니다.